### PR TITLE
Code formatting

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,8 @@
+{
+    "version": 1,
+    "lineLength": 120,
+    "tabWidth": 4,
+    "indentation": {
+        "tabs": 1
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,46 +4,46 @@ import CompilerPluginSupport
 import PackageDescription
 
 let package = Package(
-  name: "swift-json-api",
-  platforms: [
-    .macOS(.v10_15),
-    .iOS(.v13),
-    .tvOS(.v13),
-    .watchOS(.v6),
-    .macCatalyst(.v13),
-  ],
-  products: [
-    .library(
-      name: "JSONAPI",
-      targets: ["JSONAPI"]
-    )
-  ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-  ],
-  targets: [
-    .target(
-      name: "JSONAPI",
-      dependencies: ["JSONAPIMacros"]
-    ),
-    .testTarget(
-      name: "JSONAPITests",
-      dependencies: ["JSONAPI"]
-    ),
-    .macro(
-      name: "JSONAPIMacros",
-      dependencies: [
-        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-      ]
-    ),
-    .testTarget(
-      name: "JSONAPIMacrosTests",
-      dependencies: [
-        "JSONAPIMacros",
-        .product(name: "MacroTesting", package: "swift-macro-testing"),
-      ]
-    ),
-  ]
+	name: "swift-json-api",
+	platforms: [
+		.macOS(.v10_15),
+		.iOS(.v13),
+		.tvOS(.v13),
+		.watchOS(.v6),
+		.macCatalyst(.v13),
+	],
+	products: [
+		.library(
+			name: "JSONAPI",
+			targets: ["JSONAPI"]
+		)
+	],
+	dependencies: [
+		.package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
+		.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
+	],
+	targets: [
+		.target(
+			name: "JSONAPI",
+			dependencies: ["JSONAPIMacros"]
+		),
+		.testTarget(
+			name: "JSONAPITests",
+			dependencies: ["JSONAPI"]
+		),
+		.macro(
+			name: "JSONAPIMacros",
+			dependencies: [
+				.product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+			]
+		),
+		.testTarget(
+			name: "JSONAPIMacrosTests",
+			dependencies: [
+				"JSONAPIMacros",
+				.product(name: "MacroTesting", package: "swift-macro-testing"),
+			]
+		),
+	]
 )

--- a/Sources/JSONAPI/DecoderExtensions.swift
+++ b/Sources/JSONAPI/DecoderExtensions.swift
@@ -1,50 +1,50 @@
 import Foundation
 
 extension JSONDecoder {
-  public var decodesIncludedResources: Bool {
-    get {
-      userInfo.includedResourceDecoderStorage != nil
-    }
-    set {
-      userInfo.includedResourceDecoderStorage = newValue ? IncludedResourceDecoderStorage() : nil
-    }
-  }
+	public var decodesIncludedResources: Bool {
+		get {
+			userInfo.includedResourceDecoderStorage != nil
+		}
+		set {
+			userInfo.includedResourceDecoderStorage = newValue ? IncludedResourceDecoderStorage() : nil
+		}
+	}
 
-  public func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: DecodableResource {
-    self.decodesIncludedResources = true
-    return try self.decode(Document<T>.self, from: data).data
-  }
+	public func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: DecodableResource {
+		self.decodesIncludedResources = true
+		return try self.decode(Document<T>.self, from: data).data
+	}
 
-  public func decode<T>(
-    _ type: T.Type,
-    from data: Data
-  ) throws -> T where T: RangeReplaceableCollection, T: Decodable, T.Element: DecodableResource {
-    self.decodesIncludedResources = true
-    return try self.decode(Document<T?>.self, from: data).data ?? T()
-  }
+	public func decode<T>(
+		_ type: T.Type,
+		from data: Data
+	) throws -> T where T: RangeReplaceableCollection, T: Decodable, T.Element: DecodableResource {
+		self.decodesIncludedResources = true
+		return try self.decode(Document<T?>.self, from: data).data ?? T()
+	}
 }
 
 extension Decoder {
-  public var includedResourceDecoder: IncludedResourceDecoder? {
-    userInfo.includedResourceDecoderStorage?.includedResourceDecoder
-  }
+	public var includedResourceDecoder: IncludedResourceDecoder? {
+		userInfo.includedResourceDecoderStorage?.includedResourceDecoder
+	}
 }
 
 extension Dictionary where Key == CodingUserInfoKey, Value == Any {
-  fileprivate(set) var includedResourceDecoderStorage: IncludedResourceDecoderStorage? {
-    get {
-      self[IncludedResourceDecoderStorage.key] as? IncludedResourceDecoderStorage
-    }
-    set {
-      self[IncludedResourceDecoderStorage.key] = newValue
-    }
-  }
+	fileprivate(set) var includedResourceDecoderStorage: IncludedResourceDecoderStorage? {
+		get {
+			self[IncludedResourceDecoderStorage.key] as? IncludedResourceDecoderStorage
+		}
+		set {
+			self[IncludedResourceDecoderStorage.key] = newValue
+		}
+	}
 }
 
 final class IncludedResourceDecoderStorage {
-  fileprivate static let key = CodingUserInfoKey(
-    rawValue: "JSONAPI.IncludedResourceDecoderStorage"
-  )!
+	fileprivate static let key = CodingUserInfoKey(
+		rawValue: "JSONAPI.IncludedResourceDecoderStorage"
+	)!
 
-  var includedResourceDecoder: IncludedResourceDecoder?
+	var includedResourceDecoder: IncludedResourceDecoder?
 }

--- a/Sources/JSONAPI/Document.swift
+++ b/Sources/JSONAPI/Document.swift
@@ -1,47 +1,47 @@
 import Foundation
 
 public struct Document<Content> {
-  public var data: Content
+	public var data: Content
 
-  public init(data: Content) {
-    self.data = data
-  }
+	public init(data: Content) {
+		self.data = data
+	}
 }
 
 extension Document: Equatable where Content: Equatable {
 }
 
 extension Document: Decodable where Content: Decodable {
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    // Make the included resource decoder available to child decoders if there are any included resources
-    if let includedResourceDecoderStorage = decoder.userInfo.includedResourceDecoderStorage {
-      let identifiers =
-        try container.decodeIfPresent([ResourceIdentifier].self, forKey: .included) ?? []
-      let includedResourceDecoder = IncludedResourceDecoder(identifiers: identifiers) {
-        try container.nestedUnkeyedContainer(forKey: .included)
-      }
-      includedResourceDecoderStorage.includedResourceDecoder = includedResourceDecoder
-    }
+		// Make the included resource decoder available to child decoders if there are any included resources
+		if let includedResourceDecoderStorage = decoder.userInfo.includedResourceDecoderStorage {
+			let identifiers =
+				try container.decodeIfPresent([ResourceIdentifier].self, forKey: .included) ?? []
+			let includedResourceDecoder = IncludedResourceDecoder(identifiers: identifiers) {
+				try container.nestedUnkeyedContainer(forKey: .included)
+			}
+			includedResourceDecoderStorage.includedResourceDecoder = includedResourceDecoder
+		}
 
-    self.data = try container.decode(Content.self, forKey: .data)
-  }
+		self.data = try container.decode(Content.self, forKey: .data)
+	}
 }
 
 extension Document: Encodable where Content: Encodable {
-  public func encode(to encoder: any Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
+	public func encode(to encoder: any Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
 
-    try container.encode(self.data, forKey: .data)
+		try container.encode(self.data, forKey: .data)
 
-    var includedContainer = container.nestedUnkeyedContainer(forKey: .included)
-    try encoder.includedResourceEncoder?.encodeResources(into: &includedContainer)
-  }
+		var includedContainer = container.nestedUnkeyedContainer(forKey: .included)
+		try encoder.includedResourceEncoder?.encodeResources(into: &includedContainer)
+	}
 }
 
 extension Document {
-  fileprivate enum CodingKeys: String, CodingKey {
-    case data, included
-  }
+	fileprivate enum CodingKeys: String, CodingKey {
+		case data, included
+	}
 }

--- a/Sources/JSONAPI/EncoderExtensions.swift
+++ b/Sources/JSONAPI/EncoderExtensions.swift
@@ -1,41 +1,41 @@
 import Foundation
 
 extension JSONEncoder {
-  public var encodesIncludedResources: Bool {
-    get {
-      userInfo.includedResourceEncoder != nil
-    }
-    set {
-      userInfo.includedResourceEncoder = newValue ? IncludedResourceEncoder() : nil
-    }
-  }
+	public var encodesIncludedResources: Bool {
+		get {
+			userInfo.includedResourceEncoder != nil
+		}
+		set {
+			userInfo.includedResourceEncoder = newValue ? IncludedResourceEncoder() : nil
+		}
+	}
 
-  public func encode<T>(_ value: T) throws -> Data where T: EncodableResource {
-    self.encodesIncludedResources = true
-    return try self.encode(Document(data: value))
-  }
+	public func encode<T>(_ value: T) throws -> Data where T: EncodableResource {
+		self.encodesIncludedResources = true
+		return try self.encode(Document(data: value))
+	}
 
-  public func encode<T>(
-    _ value: T
-  ) throws -> Data where T: Collection, T: Encodable, T.Element: EncodableResource {
-    self.encodesIncludedResources = true
-    return try self.encode(Document(data: value))
-  }
+	public func encode<T>(
+		_ value: T
+	) throws -> Data where T: Collection, T: Encodable, T.Element: EncodableResource {
+		self.encodesIncludedResources = true
+		return try self.encode(Document(data: value))
+	}
 }
 
 extension Encoder {
-  public var includedResourceEncoder: IncludedResourceEncoder? {
-    userInfo.includedResourceEncoder
-  }
+	public var includedResourceEncoder: IncludedResourceEncoder? {
+		userInfo.includedResourceEncoder
+	}
 }
 
 extension Dictionary where Key == CodingUserInfoKey, Value == Any {
-  fileprivate var includedResourceEncoder: IncludedResourceEncoder? {
-    get {
-      self[IncludedResourceEncoder.key] as? IncludedResourceEncoder
-    }
-    set {
-      self[IncludedResourceEncoder.key] = newValue
-    }
-  }
+	fileprivate var includedResourceEncoder: IncludedResourceEncoder? {
+		get {
+			self[IncludedResourceEncoder.key] as? IncludedResourceEncoder
+		}
+		set {
+			self[IncludedResourceEncoder.key] = newValue
+		}
+	}
 }

--- a/Sources/JSONAPI/Error.swift
+++ b/Sources/JSONAPI/Error.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum DocumentDecodingError: Error {
-  case includedResourceDecodingNotEnabled
+	case includedResourceDecodingNotEnabled
 }
 
 public enum DocumentEncodingError: Error {
-  case includedResourceEncodingNotEnabled
+	case includedResourceEncodingNotEnabled
 }

--- a/Sources/JSONAPI/IncludedResourceDecoder.swift
+++ b/Sources/JSONAPI/IncludedResourceDecoder.swift
@@ -1,96 +1,96 @@
 import Foundation
 
 public final class IncludedResourceDecoder {
-  private let container: () throws -> any UnkeyedDecodingContainer
-  private let indexByIdentifier: [ResourceIdentifier: Int]
+	private let container: () throws -> any UnkeyedDecodingContainer
+	private let indexByIdentifier: [ResourceIdentifier: Int]
 
-  init(
-    identifiers: [ResourceIdentifier],
-    container: @escaping () throws -> any UnkeyedDecodingContainer
-  ) {
-    self.indexByIdentifier = Dictionary(
-      zip(identifiers, identifiers.indices),
-      uniquingKeysWith: { first, _ in first }
-    )
-    self.container = container
-  }
+	init(
+		identifiers: [ResourceIdentifier],
+		container: @escaping () throws -> any UnkeyedDecodingContainer
+	) {
+		self.indexByIdentifier = Dictionary(
+			zip(identifiers, identifiers.indices),
+			uniquingKeysWith: { first, _ in first }
+		)
+		self.container = container
+	}
 
-  public func decode<T>(
-    _ type: T.Type,
-    forRelationship relationship: RelationshipToOne
-  ) throws -> T where T: DecodableResource {
-    try self.decode(type, forIdentifier: relationship.data)
-  }
+	public func decode<T>(
+		_ type: T.Type,
+		forRelationship relationship: RelationshipToOne
+	) throws -> T where T: DecodableResource {
+		try self.decode(type, forIdentifier: relationship.data)
+	}
 
-  public func decode<T>(
-    _ type: [T].Type,
-    forRelationship relationship: RelationshipToMany
-  ) throws -> [T] where T: DecodableResource {
-    try relationship.data.map {
-      try self.decode(T.self, forIdentifier: $0)
-    }
-  }
+	public func decode<T>(
+		_ type: [T].Type,
+		forRelationship relationship: RelationshipToMany
+	) throws -> [T] where T: DecodableResource {
+		try relationship.data.map {
+			try self.decode(T.self, forIdentifier: $0)
+		}
+	}
 
-  public func decodeIfPresent<T>(
-    _ type: T.Type,
-    forRelationship relationship: OptionalRelationshipToOne?
-  ) throws -> T? where T: DecodableResource {
-    guard let data = relationship?.data else {
-      return nil
-    }
-    return try decodeIfPresent(type, forIdentifier: data)
-  }
+	public func decodeIfPresent<T>(
+		_ type: T.Type,
+		forRelationship relationship: OptionalRelationshipToOne?
+	) throws -> T? where T: DecodableResource {
+		guard let data = relationship?.data else {
+			return nil
+		}
+		return try decodeIfPresent(type, forIdentifier: data)
+	}
 
-  public func decodeIfPresent<T>(
-    _ type: [T].Type,
-    forRelationship relationship: RelationshipToMany?
-  ) throws -> [T]? where T: DecodableResource {
-    guard let data = relationship?.data else {
-      return nil
-    }
-    return try data.compactMap {
-      try self.decodeIfPresent(T.self, forIdentifier: $0)
-    }
-  }
+	public func decodeIfPresent<T>(
+		_ type: [T].Type,
+		forRelationship relationship: RelationshipToMany?
+	) throws -> [T]? where T: DecodableResource {
+		guard let data = relationship?.data else {
+			return nil
+		}
+		return try data.compactMap {
+			try self.decodeIfPresent(T.self, forIdentifier: $0)
+		}
+	}
 
-  private func decode<T>(
-    _ type: T.Type,
-    forIdentifier identifier: ResourceIdentifier
-  ) throws -> T where T: DecodableResource {
-    guard let resource = try self.decodeIfPresent(type, forIdentifier: identifier) else {
-      throw DecodingError.valueNotFound(
-        type,
-        .init(
-          codingPath: (try? self.container())?.codingPath ?? [],
-          debugDescription:
-            "Could not find resource of type '\(identifier.type)' with id '\(identifier.id)'."
-        )
-      )
-    }
+	private func decode<T>(
+		_ type: T.Type,
+		forIdentifier identifier: ResourceIdentifier
+	) throws -> T where T: DecodableResource {
+		guard let resource = try self.decodeIfPresent(type, forIdentifier: identifier) else {
+			throw DecodingError.valueNotFound(
+				type,
+				.init(
+					codingPath: (try? self.container())?.codingPath ?? [],
+					debugDescription:
+						"Could not find resource of type '\(identifier.type)' with id '\(identifier.id)'."
+				)
+			)
+		}
 
-    return resource
-  }
+		return resource
+	}
 
-  private func decodeIfPresent<T>(
-    _ type: T.Type,
-    forIdentifier identifier: ResourceIdentifier
-  ) throws -> T? where T: DecodableResource {
-    guard let index = self.indexByIdentifier[identifier] else {
-      return nil
-    }
+	private func decodeIfPresent<T>(
+		_ type: T.Type,
+		forIdentifier identifier: ResourceIdentifier
+	) throws -> T? where T: DecodableResource {
+		guard let index = self.indexByIdentifier[identifier] else {
+			return nil
+		}
 
-    return try self.decode(T.self, at: index)
-  }
+		return try self.decode(T.self, at: index)
+	}
 
-  private func decode<T>(_ type: T.Type, at index: Int) throws -> T where T: DecodableResource {
-    var container = try self.container()
+	private func decode<T>(_ type: T.Type, at index: Int) throws -> T where T: DecodableResource {
+		var container = try self.container()
 
-    precondition(index < container.count!)
+		precondition(index < container.count!)
 
-    while container.currentIndex < index {
-      _ = try container.decode(ResourceIdentifier.self)
-    }
+		while container.currentIndex < index {
+			_ = try container.decode(ResourceIdentifier.self)
+		}
 
-    return try container.decode(T.self)
-  }
+		return try container.decode(T.self)
+	}
 }

--- a/Sources/JSONAPI/IncludedResourceEncoder.swift
+++ b/Sources/JSONAPI/IncludedResourceEncoder.swift
@@ -1,58 +1,58 @@
 import Foundation
 
 public final class IncludedResourceEncoder {
-  static let key = CodingUserInfoKey(rawValue: "JSONAPI.IncludedResourceEncoder")!
+	static let key = CodingUserInfoKey(rawValue: "JSONAPI.IncludedResourceEncoder")!
 
-  private struct EncodeInvocation {
-    var invoke:
-      (
-        _ identifiers: inout Set<ResourceIdentifier>,
-        _ container: inout UnkeyedEncodingContainer
-      ) throws -> Void
+	private struct EncodeInvocation {
+		var invoke:
+			(
+				_ identifiers: inout Set<ResourceIdentifier>,
+				_ container: inout UnkeyedEncodingContainer
+			) throws -> Void
 
-    init<T>(resource: T) where T: EncodableResource {
-      self.invoke = { encodedResources, container in
-        let resourceIdentifier = resource.resourceIdentifier
+		init<T>(resource: T) where T: EncodableResource {
+			self.invoke = { encodedResources, container in
+				let resourceIdentifier = resource.resourceIdentifier
 
-        guard !encodedResources.contains(resourceIdentifier) else {
-          return
-        }
+				guard !encodedResources.contains(resourceIdentifier) else {
+					return
+				}
 
-        try container.encode(resource)
-        encodedResources.insert(resourceIdentifier)
-      }
-    }
-  }
+				try container.encode(resource)
+				encodedResources.insert(resourceIdentifier)
+			}
+		}
+	}
 
-  private var encodeInvocations: [EncodeInvocation] = []
+	private var encodeInvocations: [EncodeInvocation] = []
 
-  public func encode<T>(_ value: T) where T: EncodableResource {
-    // Defer encoding to avoid simultaneous accesses
-    encodeInvocations.append(.init(resource: value))
-  }
+	public func encode<T>(_ value: T) where T: EncodableResource {
+		// Defer encoding to avoid simultaneous accesses
+		encodeInvocations.append(.init(resource: value))
+	}
 
-  public func encodeIfPresent<T>(_ value: T?) where T: EncodableResource {
-    guard let value else { return }
-    self.encode(value)
-  }
+	public func encodeIfPresent<T>(_ value: T?) where T: EncodableResource {
+		guard let value else { return }
+		self.encode(value)
+	}
 
-  public func encode<S>(_ sequence: S) where S: Sequence, S.Element: EncodableResource {
-    for element in sequence {
-      self.encode(element)
-    }
-  }
+	public func encode<S>(_ sequence: S) where S: Sequence, S.Element: EncodableResource {
+		for element in sequence {
+			self.encode(element)
+		}
+	}
 
-  public func encodeIfPresent<S>(_ sequence: S?) where S: Sequence, S.Element: EncodableResource {
-    guard let sequence else { return }
-    self.encode(sequence)
-  }
+	public func encodeIfPresent<S>(_ sequence: S?) where S: Sequence, S.Element: EncodableResource {
+		guard let sequence else { return }
+		self.encode(sequence)
+	}
 
-  func encodeResources(into container: inout UnkeyedEncodingContainer) throws {
-    var encodedResources: Set<ResourceIdentifier> = []
+	func encodeResources(into container: inout UnkeyedEncodingContainer) throws {
+		var encodedResources: Set<ResourceIdentifier> = []
 
-    // Invocations can enqueue more invocations
-    while !encodeInvocations.isEmpty {
-      try encodeInvocations.removeFirst().invoke(&encodedResources, &container)
-    }
-  }
+		// Invocations can enqueue more invocations
+		while !encodeInvocations.isEmpty {
+			try encodeInvocations.removeFirst().invoke(&encodedResources, &container)
+		}
+	}
 }

--- a/Sources/JSONAPI/Macros.swift
+++ b/Sources/JSONAPI/Macros.swift
@@ -1,29 +1,29 @@
 @attached(member, names: named(type), named(id))
 @attached(
-  extension,
-  conformances: CodableResource,
-  names:
-    named(ResourceAttributeCodingKeys),
-  named(ResourceRelationshipCodingKeys),
-  named(init(from:)),
-  named(encode(to:))
+	extension,
+	conformances: CodableResource,
+	names:
+		named(ResourceAttributeCodingKeys),
+	named(ResourceRelationshipCodingKeys),
+	named(init(from:)),
+	named(encode(to:))
 )
 public macro CodableResource(type: String) =
-  #externalMacro(
-    module: "JSONAPIMacros",
-    type: "CodableResourceMacro"
-  )
+	#externalMacro(
+		module: "JSONAPIMacros",
+		type: "CodableResourceMacro"
+	)
 
 @attached(accessor, names: named(willSet))
 public macro ResourceAttribute(key: String? = nil) =
-  #externalMacro(
-    module: "JSONAPIMacros",
-    type: "ResourceAttributeMacro"
-  )
+	#externalMacro(
+		module: "JSONAPIMacros",
+		type: "ResourceAttributeMacro"
+	)
 
 @attached(accessor, names: named(willSet))
 public macro ResourceRelationship(key: String? = nil) =
-  #externalMacro(
-    module: "JSONAPIMacros",
-    type: "ResourceRelationshipMacro"
-  )
+	#externalMacro(
+		module: "JSONAPIMacros",
+		type: "ResourceRelationshipMacro"
+	)

--- a/Sources/JSONAPI/OptionalRelationshipToOne.swift
+++ b/Sources/JSONAPI/OptionalRelationshipToOne.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public struct OptionalRelationshipToOne: Equatable, Codable {
-  public var data: ResourceIdentifier?
+	public var data: ResourceIdentifier?
 
-  public init(data: ResourceIdentifier? = nil) {
-    self.data = data
-  }
+	public init(data: ResourceIdentifier? = nil) {
+		self.data = data
+	}
 }

--- a/Sources/JSONAPI/RelationshipToMany.swift
+++ b/Sources/JSONAPI/RelationshipToMany.swift
@@ -1,25 +1,25 @@
 import Foundation
 
 public struct RelationshipToMany: Equatable, Codable {
-  public var data: [ResourceIdentifier]
+	public var data: [ResourceIdentifier]
 
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.data = try container.decodeIfPresent([ResourceIdentifier].self, forKey: .data) ?? []
-  }
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.data = try container.decodeIfPresent([ResourceIdentifier].self, forKey: .data) ?? []
+	}
 
-  public init(data: [ResourceIdentifier]) {
-    self.data = data
-  }
+	public init(data: [ResourceIdentifier]) {
+		self.data = data
+	}
 
-  public init<T>(resources: T) where T: Sequence, T.Element: Resource {
-    self.init(data: resources.map(\.resourceIdentifier))
-  }
+	public init<T>(resources: T) where T: Sequence, T.Element: Resource {
+		self.init(data: resources.map(\.resourceIdentifier))
+	}
 
-  public init?<T>(resources: T?) where T: Sequence, T.Element: Resource {
-    guard let resources else {
-      return nil
-    }
-    self.init(data: resources.map(\.resourceIdentifier))
-  }
+	public init?<T>(resources: T?) where T: Sequence, T.Element: Resource {
+		guard let resources else {
+			return nil
+		}
+		self.init(data: resources.map(\.resourceIdentifier))
+	}
 }

--- a/Sources/JSONAPI/RelationshipToOne.swift
+++ b/Sources/JSONAPI/RelationshipToOne.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 public struct RelationshipToOne: Equatable, Codable {
-  public var data: ResourceIdentifier
+	public var data: ResourceIdentifier
 
-  public init(data: ResourceIdentifier) {
-    self.data = data
-  }
+	public init(data: ResourceIdentifier) {
+		self.data = data
+	}
 
-  public init<T>(resource: T) where T: Resource {
-    self.init(data: resource.resourceIdentifier)
-  }
+	public init<T>(resource: T) where T: Resource {
+		self.init(data: resource.resourceIdentifier)
+	}
 
-  public init?<T>(resource: T?) where T: Resource {
-    guard let resource else {
-      return nil
-    }
-    self.init(data: resource.resourceIdentifier)
-  }
+	public init?<T>(resource: T?) where T: Resource {
+		guard let resource else {
+			return nil
+		}
+		self.init(data: resource.resourceIdentifier)
+	}
 }

--- a/Sources/JSONAPI/Resource.swift
+++ b/Sources/JSONAPI/Resource.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public protocol Resource {
-  associatedtype ID: Hashable & CustomStringConvertible & Codable
+	associatedtype ID: Hashable & CustomStringConvertible & Codable
 
-  static var type: String { get }
+	static var type: String { get }
 
-  var id: ID { get }
+	var id: ID { get }
 }
 
 public typealias DecodableResource = Decodable & Resource
@@ -13,7 +13,7 @@ public typealias EncodableResource = Encodable & Resource
 public typealias CodableResource = DecodableResource & EncodableResource
 
 extension Resource {
-  public var resourceIdentifier: ResourceIdentifier {
-    .init(type: Self.type, id: String(describing: self.id))
-  }
+	public var resourceIdentifier: ResourceIdentifier {
+		.init(type: Self.type, id: String(describing: self.id))
+	}
 }

--- a/Sources/JSONAPI/ResourceCodingKeys.swift
+++ b/Sources/JSONAPI/ResourceCodingKeys.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public enum ResourceCodingKeys: String, CodingKey {
-  case type, id, attributes, relationships
+	case type, id, attributes, relationships
 }

--- a/Sources/JSONAPI/ResourceIdentifier.swift
+++ b/Sources/JSONAPI/ResourceIdentifier.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public struct ResourceIdentifier: Hashable, Codable {
-  public var type: String
-  public var id: String
+	public var type: String
+	public var id: String
 
-  public init(type: String, id: String) {
-    self.type = type
-    self.id = id
-  }
+	public init(type: String, id: String) {
+		self.type = type
+		self.id = id
+	}
 }

--- a/Sources/JSONAPI/ResourceType.swift
+++ b/Sources/JSONAPI/ResourceType.swift
@@ -4,18 +4,18 @@ public struct ResourceType<T> where T: Resource {
 }
 
 extension ResourceType: Decodable {
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    let type = try container.decode(String.self)
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		let type = try container.decode(String.self)
 
-    guard type == T.type else {
-      throw DecodingError.typeMismatch(
-        T.self,
-        .init(
-          codingPath: [ResourceCodingKeys.type],
-          debugDescription: "Resource type does not match: '\(type)'"
-        )
-      )
-    }
-  }
+		guard type == T.type else {
+			throw DecodingError.typeMismatch(
+				T.self,
+				.init(
+					codingPath: [ResourceCodingKeys.type],
+					debugDescription: "Resource type does not match: '\(type)'"
+				)
+			)
+		}
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Common.swift
+++ b/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Common.swift
@@ -2,110 +2,105 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension CodableResourceMacro {
-  static let moduleName = "JSONAPI"
-  static let conformanceName = "CodableResource"
+	static let moduleName = "JSONAPI"
+	static let conformanceName = "CodableResource"
 
-  static var qualifiedConformanceName: String {
-    "\(moduleName).\(conformanceName)"
-  }
+	static var qualifiedConformanceName: String {
+		"\(moduleName).\(conformanceName)"
+	}
 
-  static let typeVariableIdentifier = "type"
-  static let idVariableIdentifier = "id"
+	static let typeVariableIdentifier = "type"
+	static let idVariableIdentifier = "id"
 
-  static let resourceAttributeMacroName = "ResourceAttribute"
-  static let resourceAttributeCodingKeysName = "ResourceAttributeCodingKeys"
+	static let resourceAttributeMacroName = "ResourceAttribute"
+	static let resourceAttributeCodingKeysName = "ResourceAttributeCodingKeys"
 
-  static let resourceRelationshipMacroName = "ResourceRelationship"
-  static let resourceRelationshipCodingKeysName = "ResourceRelationshipCodingKeys"
+	static let resourceRelationshipMacroName = "ResourceRelationship"
+	static let resourceRelationshipCodingKeysName = "ResourceRelationshipCodingKeys"
 
-  static func type(
-    modifier: DeclModifierSyntax?,
-    value: StringSegmentSyntax
-  ) -> DeclSyntax {
-    """
-    \(modifier)static let \(raw: typeVariableIdentifier) = "\(value)"
-    """
-  }
+	static func type(
+		modifier: DeclModifierSyntax?,
+		value: StringSegmentSyntax
+	) -> DeclSyntax {
+		"""
+		\(modifier)static let \(raw: typeVariableIdentifier) = "\(value)"
+		"""
+	}
 
-  static func id(modifier: DeclModifierSyntax?) -> DeclSyntax {
-    "\(modifier)var \(raw: idVariableIdentifier): String"
-  }
+	static func id(modifier: DeclModifierSyntax?) -> DeclSyntax {
+		"\(modifier)var \(raw: idVariableIdentifier): String"
+	}
 
-  static func extensionMembers(
-    modifier: DeclModifierSyntax?,
-    idType: TypeSyntax,
-    attributes: [VariableDeclSyntax],
-    relationships: [VariableDeclSyntax]
-  ) -> DeclSyntax {
-    let attributeCodingKeys = codingKeysEnum(
-      for: attributes,
-      accessorMacro: resourceAttributeMacroName,
-      typeName: resourceAttributeCodingKeysName
-    )
-    let relationshipCodingKeys = codingKeysEnum(
-      for: relationships,
-      accessorMacro: resourceRelationshipMacroName,
-      typeName: resourceRelationshipCodingKeysName
-    )
-    let decodableInitializer = decodableInitializer(
-      modifier: modifier,
-      idType: idType,
-      attributes: attributes,
-      relationships: relationships
-    )
-    let encodeMethod = encodeMethod(
-      modifier: modifier,
-      attributes: attributes,
-      relationships: relationships
-    )
+	static func extensionMembers(
+		modifier: DeclModifierSyntax?,
+		idType: TypeSyntax,
+		attributes: [VariableDeclSyntax],
+		relationships: [VariableDeclSyntax]
+	) -> DeclSyntax {
+		let attributeCodingKeys = codingKeysEnum(
+			for: attributes,
+			accessorMacro: resourceAttributeMacroName,
+			typeName: resourceAttributeCodingKeysName
+		)
+		let relationshipCodingKeys = codingKeysEnum(
+			for: relationships,
+			accessorMacro: resourceRelationshipMacroName,
+			typeName: resourceRelationshipCodingKeysName
+		)
+		let decodableInitializer = decodableInitializer(
+			modifier: modifier,
+			idType: idType,
+			attributes: attributes,
+			relationships: relationships
+		)
+		let encodeMethod = encodeMethod(
+			modifier: modifier,
+			attributes: attributes,
+			relationships: relationships
+		)
 
-    return """
-      \(attributeCodingKeys)
-      \(relationshipCodingKeys)
-      \(decodableInitializer)
-      \(encodeMethod)
-      """
-  }
+		return """
+			\(attributeCodingKeys)
+			\(relationshipCodingKeys)
+			\(decodableInitializer)
+			\(encodeMethod)
+			"""
+	}
 
-  private static func codingKeysEnum(
-    for variables: [VariableDeclSyntax],
-    accessorMacro: String,
-    typeName: String
-  ) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func codingKeysEnum(
+		for variables: [VariableDeclSyntax],
+		accessorMacro: String,
+		typeName: String
+	) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      private enum \(raw: typeName): String, CodingKey {
-          \(codingKeysCases(for: variables, accessorMacro: accessorMacro))
-      }
-      """
-  }
+		let cases = codingKeysCases(for: variables, accessorMacro: accessorMacro)
+		return "private enum \(raw: typeName): String, CodingKey {\(cases)}"
+	}
 
-  private static func codingKeysCases(
-    for variables: [VariableDeclSyntax],
-    accessorMacro: String
-  ) -> DeclSyntax {
-    var cases: [DeclSyntax] = []
+	private static func codingKeysCases(
+		for variables: [VariableDeclSyntax],
+		accessorMacro: String
+	) -> DeclSyntax {
+		var cases: [DeclSyntax] = []
 
-    for variable in variables {
-      guard
-        let macroAttribute = variable.attribute(named: accessorMacro),
-        let identifier = variable.identifier
-      else {
-        continue
-      }
+		for variable in variables {
+			guard
+				let macroAttribute = variable.attribute(named: accessorMacro),
+				let identifier = variable.identifier
+			else {
+				continue
+			}
 
-      if let key = macroAttribute.firstArgumentStringLiteralSegment {
-        cases.append("case \(identifier) = \"\(key)\"")
-      } else {
-        cases.append("case \(identifier)")
-      }
-    }
+			if let key = macroAttribute.firstArgumentStringLiteralSegment {
+				cases.append("case \(identifier) = \"\(key)\"")
+			} else {
+				cases.append("case \(identifier)")
+			}
+		}
 
-    return """
-      \(raw: cases.map(\.description).joined(separator: "\n"))
-      """
-  }
+		return "\(raw: cases.map(\.description).joined(separator: "\n"))"
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Decoding.swift
+++ b/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Decoding.swift
@@ -2,146 +2,135 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension CodableResourceMacro {
-  static func decodableInitializer(
-    modifier: DeclModifierSyntax?,
-    idType: TypeSyntax,
-    attributes: [VariableDeclSyntax],
-    relationships: [VariableDeclSyntax]
-  ) -> DeclSyntax {
-    return """
-      \(modifier)init(from decoder: any Decoder) throws {
-          \(decodableInitializerBody(idType: idType, attributes: attributes, relationships: relationships))
-      }
-      """
-  }
+	static func decodableInitializer(
+		modifier: DeclModifierSyntax?,
+		idType: TypeSyntax,
+		attributes: [VariableDeclSyntax],
+		relationships: [VariableDeclSyntax]
+	) -> DeclSyntax {
+		let body = decodableInitializerBody(idType: idType, attributes: attributes, relationships: relationships)
+		return "\(modifier)init(from decoder: any Decoder) throws {\(body)}"
+	}
 
-  private static func decodableInitializerBody(
-    idType: TypeSyntax,
-    attributes: [VariableDeclSyntax],
-    relationships: [VariableDeclSyntax]
-  ) -> DeclSyntax {
-    return """
-      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-      _ = try container.decode(ResourceType<Self>.self, forKey: .\(raw: typeVariableIdentifier))
-      self.\(raw: idVariableIdentifier) = try container.decode(\(idType).self, forKey: .\(raw: idVariableIdentifier))
-      \(attributesDecodingContainer(attributes))\
-      \(decodeAttributes(attributes))\
-      \(includedResourceDecoder(relationships))\
-      \(relationshipDecodingContainer(relationships))\
-      \(decodeRelationships(relationships))
-      """
-  }
+	private static func decodableInitializerBody(
+		idType: TypeSyntax,
+		attributes: [VariableDeclSyntax],
+		relationships: [VariableDeclSyntax]
+	) -> DeclSyntax {
+		return """
+			let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			_ = try container.decode(ResourceType<Self>.self, forKey: .\(raw: typeVariableIdentifier))
+			self.\(raw: idVariableIdentifier) = try container.decode(\(idType).self, forKey: .\(raw: idVariableIdentifier))
+			\(attributesDecodingContainer(attributes))\
+			\(decodeAttributes(attributes))\
+			\(includedResourceDecoder(relationships))\
+			\(relationshipDecodingContainer(relationships))\
+			\(decodeRelationships(relationships))
+			"""
+	}
 
-  private static func attributesDecodingContainer(
-    _ variables: [VariableDeclSyntax]
-  ) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func attributesDecodingContainer(
+		_ variables: [VariableDeclSyntax]
+	) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      let attributesContainer = try container.nestedContainer\
-      (keyedBy: \(raw: resourceAttributeCodingKeysName).self, forKey: .attributes)
-      """
-  }
+		return """
+			let attributesContainer = try container.nestedContainer\
+			(keyedBy: \(raw: resourceAttributeCodingKeysName).self, forKey: .attributes)
+			"""
+	}
 
-  private static func decodeAttributes(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func decodeAttributes(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    let output = variables.map { variable in
-      decodeAttribute(variable).description
-    }
-    .joined(separator: "\n")
+		let output = variables.map { variable in
+			decodeAttribute(variable).description
+		}
+		.joined(separator: "\n")
 
-    return """
-      \(raw: output)
-      """
-  }
+		return "\(raw: output)"
+	}
 
-  private static func decodeAttribute(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional || variable.isArray ? "decodeIfPresent" : "decode"
-    let type = variable.isOptional ? variable.optionalWrappedType : variable.type
-    let arrayNilCoalesce: DeclSyntax = variable.isArray ? " ?? []" : ""
+	private static func decodeAttribute(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional || variable.isArray ? "decodeIfPresent" : "decode"
+		let type = variable.isOptional ? variable.optionalWrappedType : variable.type
+		let arrayNilCoalesce: DeclSyntax = variable.isArray ? " ?? []" : ""
 
-    return """
-      self.\(variable.identifier) = try attributesContainer.\
-      \(raw: method)(\(type).self, forKey: .\(variable.identifier))\(arrayNilCoalesce)
-      """
-  }
+		return """
+			self.\(variable.identifier) = try attributesContainer.\
+			\(raw: method)(\(type).self, forKey: .\(variable.identifier))\(arrayNilCoalesce)
+			"""
+	}
 
-  private static func includedResourceDecoder(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func includedResourceDecoder(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      guard let includedResourceDecoder = decoder.includedResourceDecoder else {
-        throw DocumentDecodingError.includedResourceDecodingNotEnabled
-      }
-      """
-  }
+		return """
+			guard let includedResourceDecoder = decoder.includedResourceDecoder else {\
+			throw DocumentDecodingError.includedResourceDecodingNotEnabled}
+			"""
+	}
 
-  private static func relationshipDecodingContainer(
-    _ variables: [VariableDeclSyntax]
-  ) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func relationshipDecodingContainer(
+		_ variables: [VariableDeclSyntax]
+	) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      let relationshipsContainer = try container.nestedContainer\
-      (keyedBy: \(raw: resourceRelationshipCodingKeysName).self, forKey: .relationships)
-      """
-  }
+		return """
+			let relationshipsContainer = try container.nestedContainer\
+			(keyedBy: \(raw: resourceRelationshipCodingKeysName).self, forKey: .relationships)
+			"""
+	}
 
-  private static func decodeRelationships(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func decodeRelationships(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    let output = variables.map { variable in
-      decodeRelationship(variable).description
-    }
-    .joined(separator: "\n")
+		let output = variables.map { variable in
+			decodeRelationship(variable).description
+		}
+		.joined(separator: "\n")
 
-    return """
-      \(raw: output)
-      """
-  }
+		return "\(raw: output)"
+	}
 
-  private static func decodeRelationship(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    """
-    \(decodeRelationshipModel(variable))
-    \(decodeIncluded(variable))
-    """
-  }
+	private static func decodeRelationship(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		"\(decodeRelationshipModel(variable))\(decodeIncluded(variable))"
+	}
 
-  private static func decodeRelationshipModel(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional ? "decodeIfPresent" : "decode"
-    let type = variable.isOptional ? variable.optionalWrappedType : variable.type
-    let isArray = (type?.isArray ?? false)
-    let relationshipType =
-      if variable.isOptional, !isArray {
-        "OptionalRelationshipToOne"
-      } else {
-        isArray ? "RelationshipToMany" : "RelationshipToOne"
-      }
+	private static func decodeRelationshipModel(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional ? "decodeIfPresent" : "decode"
+		let type = variable.isOptional ? variable.optionalWrappedType : variable.type
+		let isArray = (type?.isArray ?? false)
+		let relationshipType =
+			if variable.isOptional, !isArray {
+				"OptionalRelationshipToOne"
+			} else {
+				isArray ? "RelationshipToMany" : "RelationshipToOne"
+			}
 
-    return """
-      let \(variable.identifier)Relationship = try relationshipsContainer.\
-      \(raw: method)(\(raw: relationshipType).self, forKey: .\(variable.identifier))
-      """
-  }
+		return """
+			let \(variable.identifier)Relationship = try relationshipsContainer.\
+			\(raw: method)(\(raw: relationshipType).self, forKey: .\(variable.identifier))
+			"""
+	}
 
-  private static func decodeIncluded(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional ? "decodeIfPresent" : "decode"
-    let type = variable.isOptional ? variable.optionalWrappedType : variable.type
+	private static func decodeIncluded(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional ? "decodeIfPresent" : "decode"
+		let type = variable.isOptional ? variable.optionalWrappedType : variable.type
 
-    return """
-      self.\(variable.identifier) = try includedResourceDecoder.\(raw: method)\
-      (\(type).self, forRelationship: \(variable.identifier)Relationship)
-      """
-  }
+		return """
+			self.\(variable.identifier) = try includedResourceDecoder.\(raw: method)\
+			(\(type).self, forRelationship: \(variable.identifier)Relationship)
+			"""
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Encoding.swift
+++ b/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro+Encoding.swift
@@ -2,133 +2,120 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension CodableResourceMacro {
-  static func encodeMethod(
-    modifier: DeclModifierSyntax?,
-    attributes: [VariableDeclSyntax],
-    relationships: [VariableDeclSyntax]
-  ) -> DeclSyntax {
-    return """
-      \(modifier)func encode(to encoder: any Encoder) throws {
-          \(encodeMethodBody(attributes: attributes, relationships: relationships))
-      }
-      """
-  }
+	static func encodeMethod(
+		modifier: DeclModifierSyntax?,
+		attributes: [VariableDeclSyntax],
+		relationships: [VariableDeclSyntax]
+	) -> DeclSyntax {
+		let body = encodeMethodBody(attributes: attributes, relationships: relationships)
+		return "\(modifier)func encode(to encoder: any Encoder) throws {\(body)}"
+	}
 
-  private static func encodeMethodBody(
-    attributes: [VariableDeclSyntax],
-    relationships: [VariableDeclSyntax]
-  ) -> DeclSyntax {
-    return """
-      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-      try container.encode(Self.\(raw: typeVariableIdentifier), forKey: .\(raw: typeVariableIdentifier))
-      try container.encode(self.\(raw: idVariableIdentifier), forKey: .\(raw: idVariableIdentifier))
-      \(attributesEncodingContainer(attributes))\
-      \(encodeAttributes(attributes))\
-      \(includedResourceEncoder(relationships))\
-      \(relationshipEncodingContainer(relationships))\
-      \(encodeRelationships(relationships))
-      """
-  }
+	private static func encodeMethodBody(
+		attributes: [VariableDeclSyntax],
+		relationships: [VariableDeclSyntax]
+	) -> DeclSyntax {
+		return """
+			var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			try container.encode(Self.\(raw: typeVariableIdentifier), forKey: .\(raw: typeVariableIdentifier))
+			try container.encode(self.\(raw: idVariableIdentifier), forKey: .\(raw: idVariableIdentifier))
+			\(attributesEncodingContainer(attributes))\
+			\(encodeAttributes(attributes))\
+			\(includedResourceEncoder(relationships))\
+			\(relationshipEncodingContainer(relationships))\
+			\(encodeRelationships(relationships))
+			"""
+	}
 
-  private static func attributesEncodingContainer(
-    _ variables: [VariableDeclSyntax]
-  ) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func attributesEncodingContainer(
+		_ variables: [VariableDeclSyntax]
+	) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      var attributesContainer = container.nestedContainer\
-      (keyedBy: \(raw: resourceAttributeCodingKeysName).self, forKey: .attributes)
-      """
-  }
+		return """
+			var attributesContainer = container.nestedContainer\
+			(keyedBy: \(raw: resourceAttributeCodingKeysName).self, forKey: .attributes)
+			"""
+	}
 
-  private static func encodeAttributes(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func encodeAttributes(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    let output = variables.map { variable in
-      encodeAttribute(variable).description
-    }
-    .joined(separator: "\n")
+		let output = variables.map { variable in
+			encodeAttribute(variable).description
+		}
+		.joined(separator: "\n")
 
-    return """
-      \(raw: output)
-      """
-  }
+		return "\(raw: output)"
+	}
 
-  private static func encodeAttribute(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional ? "encodeIfPresent" : "encode"
+	private static func encodeAttribute(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional ? "encodeIfPresent" : "encode"
 
-    return """
-      try attributesContainer.\(raw: method)(self.\(variable.identifier), forKey: .\(variable.identifier))
-      """
-  }
+		return """
+			try attributesContainer.\(raw: method)(self.\(variable.identifier), forKey: .\(variable.identifier))
+			"""
+	}
 
-  private static func includedResourceEncoder(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
-    return """
-      guard let includedResourceEncoder = encoder.includedResourceEncoder else {
-        throw DocumentEncodingError.includedResourceEncodingNotEnabled
-      }
-      """
-  }
+	private static func includedResourceEncoder(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
+		return """
+			guard let includedResourceEncoder = encoder.includedResourceEncoder else {\
+			throw DocumentEncodingError.includedResourceEncodingNotEnabled}
+			"""
+	}
 
-  private static func relationshipEncodingContainer(
-    _ variables: [VariableDeclSyntax]
-  ) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func relationshipEncodingContainer(
+		_ variables: [VariableDeclSyntax]
+	) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    return """
-      var relationshipsContainer = container.nestedContainer\
-      (keyedBy: \(raw: resourceRelationshipCodingKeysName).self, forKey: .relationships)
-      """
-  }
+		return """
+			var relationshipsContainer = container.nestedContainer\
+			(keyedBy: \(raw: resourceRelationshipCodingKeysName).self, forKey: .relationships)
+			"""
+	}
 
-  private static func encodeRelationships(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
-    guard !variables.isEmpty else {
-      return nil
-    }
+	private static func encodeRelationships(_ variables: [VariableDeclSyntax]) -> DeclSyntax? {
+		guard !variables.isEmpty else {
+			return nil
+		}
 
-    let output = variables.map { variable in
-      encodeRelationship(variable).description
-    }
-    .joined(separator: "\n")
+		let output = variables.map { variable in
+			encodeRelationship(variable).description
+		}
+		.joined(separator: "\n")
 
-    return """
-      \(raw: output)
-      """
-  }
+		return "\(raw: output)"
+	}
 
-  private static func encodeRelationship(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    """
-    \(encodeRelationshipModel(variable))
-    \(encodeIncludedResource(variable))
-    """
-  }
+	private static func encodeRelationship(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		"\(encodeRelationshipModel(variable))\(encodeIncludedResource(variable))"
+	}
 
-  private static func encodeRelationshipModel(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional ? "encodeIfPresent" : "encode"
-    let type = variable.isOptional ? variable.optionalWrappedType : variable.type
-    let isArray = (type?.isArray ?? false)
-    let relationshipType = isArray ? "RelationshipToMany" : "RelationshipToOne"
-    let parameterLabel = isArray ? "resources" : "resource"
+	private static func encodeRelationshipModel(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional ? "encodeIfPresent" : "encode"
+		let type = variable.isOptional ? variable.optionalWrappedType : variable.type
+		let isArray = (type?.isArray ?? false)
+		let relationshipType = isArray ? "RelationshipToMany" : "RelationshipToOne"
+		let parameterLabel = isArray ? "resources" : "resource"
 
-    return """
-      try relationshipsContainer.\(raw: method)\
-      (\(raw: relationshipType)(\(raw: parameterLabel): self.\(variable.identifier)), forKey: .\(variable.identifier))
-      """
-  }
+		return """
+			try relationshipsContainer.\(raw: method)\
+			(\(raw: relationshipType)(\(raw: parameterLabel): self.\(variable.identifier)), forKey: .\(variable.identifier))
+			"""
+	}
 
-  private static func encodeIncludedResource(_ variable: VariableDeclSyntax) -> DeclSyntax {
-    let method = variable.isOptional ? "encodeIfPresent" : "encode"
-    return """
-      includedResourceEncoder.\(raw: method)(self.\(variable.identifier))
-      """
-  }
+	private static func encodeIncludedResource(_ variable: VariableDeclSyntax) -> DeclSyntax {
+		let method = variable.isOptional ? "encodeIfPresent" : "encode"
+		return "includedResourceEncoder.\(raw: method)(self.\(variable.identifier))"
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro.swift
+++ b/Sources/JSONAPIMacros/CodableResource/CodableResourceMacro.swift
@@ -7,109 +7,109 @@ public struct CodableResourceMacro {
 }
 
 extension CodableResourceMacro: MemberMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
-  ) throws -> [DeclSyntax] {
-    guard let namedDeclaration = declaration.asProtocol(NamedDeclSyntax.self) else {
-      return []
-    }
+	public static func expansion(
+		of node: AttributeSyntax,
+		providingMembersOf declaration: some DeclGroupSyntax,
+		in context: some MacroExpansionContext
+	) throws -> [DeclSyntax] {
+		guard let namedDeclaration = declaration.asProtocol(NamedDeclSyntax.self) else {
+			return []
+		}
 
-    let codableResourceType = namedDeclaration.name.trimmed
+		let codableResourceType = namedDeclaration.name.trimmed
 
-    if declaration.isEnum {
-      throw DiagnosticsError(
-        syntax: node,
-        message:
-          "'@CodableResource' cannot be applied to enumeration type \(codableResourceType.text)",
-        id: .invalidApplication
-      )
-    }
+		if declaration.isEnum {
+			throw DiagnosticsError(
+				syntax: node,
+				message:
+					"'@CodableResource' cannot be applied to enumeration type \(codableResourceType.text)",
+				id: .invalidApplication
+			)
+		}
 
-    if declaration.isClass {
-      throw DiagnosticsError(
-        syntax: node,
-        message: "'@CodableResource' cannot be applied to class type \(codableResourceType.text)",
-        id: .invalidApplication
-      )
-    }
+		if declaration.isClass {
+			throw DiagnosticsError(
+				syntax: node,
+				message:
+					"'@CodableResource' cannot be applied to class type \(codableResourceType.text)",
+				id: .invalidApplication
+			)
+		}
 
-    if declaration.isActor {
-      throw DiagnosticsError(
-        syntax: node,
-        message: "'@CodableResource' cannot be applied to actor type \(codableResourceType.text)",
-        id: .invalidApplication
-      )
-    }
+		if declaration.isActor {
+			throw DiagnosticsError(
+				syntax: node,
+				message:
+					"'@CodableResource' cannot be applied to actor type \(codableResourceType.text)",
+				id: .invalidApplication
+			)
+		}
 
-    guard
-      let resourceType = node.firstArgumentStringLiteralSegment,
-      !resourceType.content.text.isEmpty
-    else {
-      throw DiagnosticsError(
-        syntax: node,
-        message:
-          "'@CodableResource' requires a non-empty string literal containing the type of the resource",
-        id: .missingResourceType
-      )
-    }
+		guard
+			let resourceType = node.firstArgumentStringLiteralSegment,
+			!resourceType.content.text.isEmpty
+		else {
+			throw DiagnosticsError(
+				syntax: node,
+				message:
+					"'@CodableResource' requires a non-empty string literal containing the type of the resource",
+				id: .missingResourceType
+			)
+		}
 
-    var declarations = [DeclSyntax]()
+		var declarations = [DeclSyntax]()
 
-    // Add required properties
-    declaration.addIfNeeded(
-      self.id(modifier: declaration.publicModifier),
-      to: &declarations
-    )
-    declaration.addIfNeeded(
-      self.type(modifier: declaration.publicModifier, value: resourceType),
-      to: &declarations
-    )
+		// Add required properties
+		declaration.addIfNeeded(
+			self.id(modifier: declaration.publicModifier),
+			to: &declarations
+		)
+		declaration.addIfNeeded(
+			self.type(modifier: declaration.publicModifier, value: resourceType),
+			to: &declarations
+		)
 
-    return declarations
-  }
+		return declarations
+	}
 }
 
 extension CodableResourceMacro: ExtensionMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
-  ) throws -> [ExtensionDeclSyntax] {
-    // The user may have already defined an 'id' variable with a tagged type instead of 'String'.
-    let idType =
-      declaration.definedVariables.first { variable in
-        variable.identifier?.text == idVariableIdentifier
-      }?.type ?? IdentifierTypeSyntax(name: .identifier("String")).cast(TypeSyntax.self)
+	public static func expansion(
+		of node: AttributeSyntax,
+		attachedTo declaration: some DeclGroupSyntax,
+		providingExtensionsOf type: some TypeSyntaxProtocol,
+		conformingTo protocols: [TypeSyntax],
+		in context: some MacroExpansionContext
+	) throws -> [ExtensionDeclSyntax] {
+		// The user may have already defined an 'id' variable with a tagged type instead of 'String'.
+		let idType =
+			declaration.definedVariables.first { variable in
+				variable.identifier?.text == idVariableIdentifier
+			}?.type ?? IdentifierTypeSyntax(name: .identifier("String")).cast(TypeSyntax.self)
 
-    let attributes = declaration.definedVariables.filter { variable in
-      variable.hasMacroApplication(resourceAttributeMacroName)
-    }
+		let attributes = declaration.definedVariables.filter { variable in
+			variable.hasMacroApplication(resourceAttributeMacroName)
+		}
 
-    let relationships = declaration.definedVariables.filter { variable in
-      variable.hasMacroApplication(resourceRelationshipMacroName)
-    }
+		let relationships = declaration.definedVariables.filter { variable in
+			variable.hasMacroApplication(resourceRelationshipMacroName)
+		}
 
-    let extensionMembers = extensionMembers(
-      modifier: declaration.publicModifier,
-      idType: idType,
-      attributes: attributes,
-      relationships: relationships
-    )
+		let extensionMembers = extensionMembers(
+			modifier: declaration.publicModifier,
+			idType: idType,
+			attributes: attributes,
+			relationships: relationships
+		)
 
-    let extensionDecl = DeclSyntax(
-      """
-      \(declaration.attributes.availability)
-      extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {
-        \(extensionMembers)
-      }
-      """
-    )
-    .cast(ExtensionDeclSyntax.self)
+		let extensionDecl = DeclSyntax(
+			"""
+			\(declaration.attributes.availability)
+			extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {\(extensionMembers)}
+			"""
+		)
+		.cast(ExtensionDeclSyntax.self)
 
-    return [extensionDecl]
-  }
+		return [extensionDecl]
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/ResourceAttributeMacro.swift
+++ b/Sources/JSONAPIMacros/CodableResource/ResourceAttributeMacro.swift
@@ -3,21 +3,21 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 public struct ResourceAttributeMacro: AccessorMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingAccessorsOf declaration: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
-  ) throws -> [AccessorDeclSyntax] {
-    if let key = node.firstArgumentStringLiteralSegment {
-      guard !key.content.text.isEmpty else {
-        throw DiagnosticsError(
-          syntax: node,
-          message:
-            "'@ResourceAttribute' requires a non-empty string literal containing the key or 'nil'",
-          id: .missingKey
-        )
-      }
-    }
-    return []
-  }
+	public static func expansion(
+		of node: AttributeSyntax,
+		providingAccessorsOf declaration: some DeclSyntaxProtocol,
+		in context: some MacroExpansionContext
+	) throws -> [AccessorDeclSyntax] {
+		if let key = node.firstArgumentStringLiteralSegment {
+			guard !key.content.text.isEmpty else {
+				throw DiagnosticsError(
+					syntax: node,
+					message:
+						"'@ResourceAttribute' requires a non-empty string literal containing the key or 'nil'",
+					id: .missingKey
+				)
+			}
+		}
+		return []
+	}
 }

--- a/Sources/JSONAPIMacros/CodableResource/ResourceRelationshipMacro.swift
+++ b/Sources/JSONAPIMacros/CodableResource/ResourceRelationshipMacro.swift
@@ -3,21 +3,21 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 public struct ResourceRelationshipMacro: AccessorMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingAccessorsOf declaration: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
-  ) throws -> [AccessorDeclSyntax] {
-    if let key = node.firstArgumentStringLiteralSegment {
-      guard !key.content.text.isEmpty else {
-        throw DiagnosticsError(
-          syntax: node,
-          message:
-            "'@ResourceRelationship' requires a non-empty string literal containing the key or 'nil'",
-          id: .missingKey
-        )
-      }
-    }
-    return []
-  }
+	public static func expansion(
+		of node: AttributeSyntax,
+		providingAccessorsOf declaration: some DeclSyntaxProtocol,
+		in context: some MacroExpansionContext
+	) throws -> [AccessorDeclSyntax] {
+		if let key = node.firstArgumentStringLiteralSegment {
+			guard !key.content.text.isEmpty else {
+				throw DiagnosticsError(
+					syntax: node,
+					message:
+						"'@ResourceRelationship' requires a non-empty string literal containing the key or 'nil'",
+					id: .missingKey
+				)
+			}
+		}
+		return []
+	}
 }

--- a/Sources/JSONAPIMacros/Helpers/AppleAvailability.swift
+++ b/Sources/JSONAPIMacros/Helpers/AppleAvailability.swift
@@ -16,92 +16,92 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 extension AttributeSyntax {
-  var availability: AttributeSyntax? {
-    if attributeName.identifier == "available" {
-      return self
-    } else {
-      return nil
-    }
-  }
+	var availability: AttributeSyntax? {
+		if attributeName.identifier == "available" {
+			return self
+		} else {
+			return nil
+		}
+	}
 }
 
 extension IfConfigClauseSyntax.Elements {
-  var availability: IfConfigClauseSyntax.Elements? {
-    switch self {
-    case .attributes(let attributes):
-      if let availability = attributes.availability {
-        return .attributes(availability)
-      } else {
-        return nil
-      }
-    default:
-      return nil
-    }
-  }
+	var availability: IfConfigClauseSyntax.Elements? {
+		switch self {
+		case .attributes(let attributes):
+			if let availability = attributes.availability {
+				return .attributes(availability)
+			} else {
+				return nil
+			}
+		default:
+			return nil
+		}
+	}
 }
 
 extension IfConfigClauseSyntax {
-  var availability: IfConfigClauseSyntax? {
-    if let availability = elements?.availability {
-      return with(\.elements, availability)
-    } else {
-      return nil
-    }
-  }
+	var availability: IfConfigClauseSyntax? {
+		if let availability = elements?.availability {
+			return with(\.elements, availability)
+		} else {
+			return nil
+		}
+	}
 
-  var clonedAsIf: IfConfigClauseSyntax {
-    detached.with(\.poundKeyword, .poundIfToken())
-  }
+	var clonedAsIf: IfConfigClauseSyntax {
+		detached.with(\.poundKeyword, .poundIfToken())
+	}
 }
 
 extension IfConfigDeclSyntax {
-  var availability: IfConfigDeclSyntax? {
-    var elements = [IfConfigClauseListSyntax.Element]()
-    for clause in clauses {
-      if let availability = clause.availability {
-        if elements.isEmpty {
-          elements.append(availability.clonedAsIf)
-        } else {
-          elements.append(availability)
-        }
-      }
-    }
-    if elements.isEmpty {
-      return nil
-    } else {
-      return with(\.clauses, IfConfigClauseListSyntax(elements))
-    }
+	var availability: IfConfigDeclSyntax? {
+		var elements = [IfConfigClauseListSyntax.Element]()
+		for clause in clauses {
+			if let availability = clause.availability {
+				if elements.isEmpty {
+					elements.append(availability.clonedAsIf)
+				} else {
+					elements.append(availability)
+				}
+			}
+		}
+		if elements.isEmpty {
+			return nil
+		} else {
+			return with(\.clauses, IfConfigClauseListSyntax(elements))
+		}
 
-  }
+	}
 }
 
 extension AttributeListSyntax.Element {
-  var availability: AttributeListSyntax.Element? {
-    switch self {
-    case .attribute(let attribute):
-      if let availability = attribute.availability {
-        return .attribute(availability)
-      }
-    case .ifConfigDecl(let ifConfig):
-      if let availability = ifConfig.availability {
-        return .ifConfigDecl(availability)
-      }
-    }
-    return nil
-  }
+	var availability: AttributeListSyntax.Element? {
+		switch self {
+		case .attribute(let attribute):
+			if let availability = attribute.availability {
+				return .attribute(availability)
+			}
+		case .ifConfigDecl(let ifConfig):
+			if let availability = ifConfig.availability {
+				return .ifConfigDecl(availability)
+			}
+		}
+		return nil
+	}
 }
 
 extension AttributeListSyntax {
-  var availability: AttributeListSyntax? {
-    var elements = [AttributeListSyntax.Element]()
-    for element in self {
-      if let availability = element.availability {
-        elements.append(availability)
-      }
-    }
-    if elements.isEmpty {
-      return nil
-    }
-    return AttributeListSyntax(elements)
-  }
+	var availability: AttributeListSyntax? {
+		var elements = [AttributeListSyntax.Element]()
+		for element in self {
+			if let availability = element.availability {
+				elements.append(availability)
+			}
+		}
+		if elements.isEmpty {
+			return nil
+		}
+		return AttributeListSyntax(elements)
+	}
 }

--- a/Sources/JSONAPIMacros/Helpers/AppleExtensions.swift
+++ b/Sources/JSONAPIMacros/Helpers/AppleExtensions.swift
@@ -16,263 +16,266 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 extension VariableDeclSyntax {
-  var identifierPattern: IdentifierPatternSyntax? {
-    bindings.first?.pattern.as(IdentifierPatternSyntax.self)
-  }
+	var identifierPattern: IdentifierPatternSyntax? {
+		bindings.first?.pattern.as(IdentifierPatternSyntax.self)
+	}
 
-  var isInstance: Bool {
-    for modifier in modifiers {
-      for token in modifier.tokens(viewMode: .all) {
-        if token.tokenKind == .keyword(.static) || token.tokenKind == .keyword(.class) {
-          return false
-        }
-      }
-    }
-    return true
-  }
+	var isInstance: Bool {
+		for modifier in modifiers {
+			for token in modifier.tokens(viewMode: .all) {
+				if token.tokenKind == .keyword(.static) || token.tokenKind == .keyword(.class) {
+					return false
+				}
+			}
+		}
+		return true
+	}
 
-  var identifier: TokenSyntax? {
-    identifierPattern?.identifier
-  }
+	var identifier: TokenSyntax? {
+		identifierPattern?.identifier
+	}
 
-  var type: TypeSyntax? {
-    bindings.first?.typeAnnotation?.type
-  }
+	var type: TypeSyntax? {
+		bindings.first?.typeAnnotation?.type
+	}
 
-  func accessorsMatching(_ predicate: (TokenKind) -> Bool) -> [AccessorDeclSyntax] {
-    let accessors: [AccessorDeclListSyntax.Element] = bindings.compactMap { patternBinding in
-      switch patternBinding.accessorBlock?.accessors {
-      case .accessors(let accessors):
-        return accessors
-      default:
-        return nil
-      }
-    }.flatMap { $0 }
-    return accessors.compactMap { accessor in
-      if predicate(accessor.accessorSpecifier.tokenKind) {
-        return accessor
-      } else {
-        return nil
-      }
-    }
-  }
+	func accessorsMatching(_ predicate: (TokenKind) -> Bool) -> [AccessorDeclSyntax] {
+		let accessors: [AccessorDeclListSyntax.Element] = bindings.compactMap { patternBinding in
+			switch patternBinding.accessorBlock?.accessors {
+			case .accessors(let accessors):
+				return accessors
+			default:
+				return nil
+			}
+		}.flatMap { $0 }
+		return accessors.compactMap { accessor in
+			if predicate(accessor.accessorSpecifier.tokenKind) {
+				return accessor
+			} else {
+				return nil
+			}
+		}
+	}
 
-  var willSetAccessors: [AccessorDeclSyntax] {
-    accessorsMatching { $0 == .keyword(.willSet) }
-  }
-  var didSetAccessors: [AccessorDeclSyntax] {
-    accessorsMatching { $0 == .keyword(.didSet) }
-  }
+	var willSetAccessors: [AccessorDeclSyntax] {
+		accessorsMatching { $0 == .keyword(.willSet) }
+	}
+	var didSetAccessors: [AccessorDeclSyntax] {
+		accessorsMatching { $0 == .keyword(.didSet) }
+	}
 
-  var isComputed: Bool {
-    if accessorsMatching({ $0 == .keyword(.get) }).count > 0 {
-      return true
-    } else {
-      return bindings.contains { binding in
-        if case .getter = binding.accessorBlock?.accessors {
-          return true
-        } else {
-          return false
-        }
-      }
-    }
-  }
+	var isComputed: Bool {
+		if accessorsMatching({ $0 == .keyword(.get) }).count > 0 {
+			return true
+		} else {
+			return bindings.contains { binding in
+				if case .getter = binding.accessorBlock?.accessors {
+					return true
+				} else {
+					return false
+				}
+			}
+		}
+	}
 
-  var isImmutable: Bool {
-    return bindingSpecifier.tokenKind == .keyword(.let)
-  }
+	var isImmutable: Bool {
+		return bindingSpecifier.tokenKind == .keyword(.let)
+	}
 
-  func isEquivalent(to other: VariableDeclSyntax) -> Bool {
-    if isInstance != other.isInstance {
-      return false
-    }
-    return identifier?.text == other.identifier?.text
-  }
+	func isEquivalent(to other: VariableDeclSyntax) -> Bool {
+		if isInstance != other.isInstance {
+			return false
+		}
+		return identifier?.text == other.identifier?.text
+	}
 
-  var initializer: InitializerClauseSyntax? {
-    bindings.first?.initializer
-  }
+	var initializer: InitializerClauseSyntax? {
+		bindings.first?.initializer
+	}
 
-  func hasMacroApplication(_ name: String) -> Bool {
-    for attribute in attributes {
-      switch attribute {
-      case .attribute(let attr):
-        if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [.identifier(name)] {
-          return true
-        }
-      default:
-        break
-      }
-    }
-    return false
-  }
+	func hasMacroApplication(_ name: String) -> Bool {
+		for attribute in attributes {
+			switch attribute {
+			case .attribute(let attr):
+				if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [
+					.identifier(name)
+				] {
+					return true
+				}
+			default:
+				break
+			}
+		}
+		return false
+	}
 }
 
 extension TypeSyntax {
-  var identifier: String? {
-    for token in tokens(viewMode: .all) {
-      switch token.tokenKind {
-      case .identifier(let identifier):
-        return identifier
-      default:
-        break
-      }
-    }
-    return nil
-  }
+	var identifier: String? {
+		for token in tokens(viewMode: .all) {
+			switch token.tokenKind {
+			case .identifier(let identifier):
+				return identifier
+			default:
+				break
+			}
+		}
+		return nil
+	}
 
-  func genericSubstitution(_ parameters: GenericParameterListSyntax?) -> String? {
-    var genericParameters = [String: TypeSyntax?]()
-    if let parameters {
-      for parameter in parameters {
-        genericParameters[parameter.name.text] = parameter.inheritedType
-      }
-    }
-    var iterator = self.asProtocol(TypeSyntaxProtocol.self).tokens(viewMode: .sourceAccurate)
-      .makeIterator()
-    guard let base = iterator.next() else {
-      return nil
-    }
+	func genericSubstitution(_ parameters: GenericParameterListSyntax?) -> String? {
+		var genericParameters = [String: TypeSyntax?]()
+		if let parameters {
+			for parameter in parameters {
+				genericParameters[parameter.name.text] = parameter.inheritedType
+			}
+		}
+		var iterator = self.asProtocol(TypeSyntaxProtocol.self).tokens(viewMode: .sourceAccurate)
+			.makeIterator()
+		guard let base = iterator.next() else {
+			return nil
+		}
 
-    if let genericBase = genericParameters[base.text] {
-      if let text = genericBase?.identifier {
-        return "some " + text
-      } else {
-        return nil
-      }
-    }
-    var substituted = base.text
+		if let genericBase = genericParameters[base.text] {
+			if let text = genericBase?.identifier {
+				return "some " + text
+			} else {
+				return nil
+			}
+		}
+		var substituted = base.text
 
-    while let token = iterator.next() {
-      switch token.tokenKind {
-      case .leftAngle:
-        substituted += "<"
-      case .rightAngle:
-        substituted += ">"
-      case .comma:
-        substituted += ","
-      case .identifier(let identifier):
-        let type: TypeSyntax = "\(raw: identifier)"
-        guard let substituedType = type.genericSubstitution(parameters) else {
-          return nil
-        }
-        substituted += substituedType
-        break
-      default:
-        // ignore?
-        break
-      }
-    }
+		while let token = iterator.next() {
+			switch token.tokenKind {
+			case .leftAngle:
+				substituted += "<"
+			case .rightAngle:
+				substituted += ">"
+			case .comma:
+				substituted += ","
+			case .identifier(let identifier):
+				let type: TypeSyntax = "\(raw: identifier)"
+				guard let substituedType = type.genericSubstitution(parameters) else {
+					return nil
+				}
+				substituted += substituedType
+				break
+			default:
+				// ignore?
+				break
+			}
+		}
 
-    return substituted
-  }
+		return substituted
+	}
 }
 
 extension FunctionDeclSyntax {
-  var isInstance: Bool {
-    for modifier in modifiers {
-      for token in modifier.tokens(viewMode: .all) {
-        if token.tokenKind == .keyword(.static) || token.tokenKind == .keyword(.class) {
-          return false
-        }
-      }
-    }
-    return true
-  }
+	var isInstance: Bool {
+		for modifier in modifiers {
+			for token in modifier.tokens(viewMode: .all) {
+				if token.tokenKind == .keyword(.static) || token.tokenKind == .keyword(.class) {
+					return false
+				}
+			}
+		}
+		return true
+	}
 
-  struct SignatureStandin: Equatable {
-    var isInstance: Bool
-    var identifier: String
-    var parameters: [String]
-    var returnType: String
-  }
+	struct SignatureStandin: Equatable {
+		var isInstance: Bool
+		var identifier: String
+		var parameters: [String]
+		var returnType: String
+	}
 
-  var signatureStandin: SignatureStandin {
-    var parameters = [String]()
-    for parameter in signature.parameterClause.parameters {
-      parameters.append(
-        parameter.firstName.text + ":"
-          + (parameter.type.genericSubstitution(genericParameterClause?.parameters) ?? ""))
-    }
-    let returnType =
-      signature.returnClause?.type.genericSubstitution(genericParameterClause?.parameters) ?? "Void"
-    return SignatureStandin(
-      isInstance: isInstance, identifier: name.text, parameters: parameters, returnType: returnType)
-  }
+	var signatureStandin: SignatureStandin {
+		var parameters = [String]()
+		for parameter in signature.parameterClause.parameters {
+			parameters.append(
+				parameter.firstName.text + ":"
+					+ (parameter.type.genericSubstitution(genericParameterClause?.parameters) ?? "")
+			)
+		}
+		let returnType =
+			signature.returnClause?.type.genericSubstitution(genericParameterClause?.parameters) ?? "Void"
+		return SignatureStandin(
+			isInstance: isInstance, identifier: name.text, parameters: parameters, returnType: returnType)
+	}
 
-  func isEquivalent(to other: FunctionDeclSyntax) -> Bool {
-    return signatureStandin == other.signatureStandin
-  }
+	func isEquivalent(to other: FunctionDeclSyntax) -> Bool {
+		return signatureStandin == other.signatureStandin
+	}
 }
 
 extension DeclGroupSyntax {
-  var memberFunctionStandins: [FunctionDeclSyntax.SignatureStandin] {
-    var standins = [FunctionDeclSyntax.SignatureStandin]()
-    for member in memberBlock.members {
-      if let function = member.decl.as(FunctionDeclSyntax.self) {
-        standins.append(function.signatureStandin)
-      }
-    }
-    return standins
-  }
+	var memberFunctionStandins: [FunctionDeclSyntax.SignatureStandin] {
+		var standins = [FunctionDeclSyntax.SignatureStandin]()
+		for member in memberBlock.members {
+			if let function = member.decl.as(FunctionDeclSyntax.self) {
+				standins.append(function.signatureStandin)
+			}
+		}
+		return standins
+	}
 
-  func hasMemberFunction(equvalentTo other: FunctionDeclSyntax) -> Bool {
-    for member in memberBlock.members {
-      if let function = member.decl.as(FunctionDeclSyntax.self) {
-        if function.isEquivalent(to: other) {
-          return true
-        }
-      }
-    }
-    return false
-  }
+	func hasMemberFunction(equvalentTo other: FunctionDeclSyntax) -> Bool {
+		for member in memberBlock.members {
+			if let function = member.decl.as(FunctionDeclSyntax.self) {
+				if function.isEquivalent(to: other) {
+					return true
+				}
+			}
+		}
+		return false
+	}
 
-  func hasMemberProperty(equivalentTo other: VariableDeclSyntax) -> Bool {
-    for member in memberBlock.members {
-      if let variable = member.decl.as(VariableDeclSyntax.self) {
-        if variable.isEquivalent(to: other) {
-          return true
-        }
-      }
-    }
-    return false
-  }
+	func hasMemberProperty(equivalentTo other: VariableDeclSyntax) -> Bool {
+		for member in memberBlock.members {
+			if let variable = member.decl.as(VariableDeclSyntax.self) {
+				if variable.isEquivalent(to: other) {
+					return true
+				}
+			}
+		}
+		return false
+	}
 
-  var definedVariables: [VariableDeclSyntax] {
-    memberBlock.members.compactMap { member in
-      if let variableDecl = member.decl.as(VariableDeclSyntax.self) {
-        return variableDecl
-      }
-      return nil
-    }
-  }
+	var definedVariables: [VariableDeclSyntax] {
+		memberBlock.members.compactMap { member in
+			if let variableDecl = member.decl.as(VariableDeclSyntax.self) {
+				return variableDecl
+			}
+			return nil
+		}
+	}
 
-  func addIfNeeded(_ decl: DeclSyntax?, to declarations: inout [DeclSyntax]) {
-    guard let decl else { return }
-    if let fn = decl.as(FunctionDeclSyntax.self) {
-      if !hasMemberFunction(equvalentTo: fn) {
-        declarations.append(decl)
-      }
-    } else if let property = decl.as(VariableDeclSyntax.self) {
-      if !hasMemberProperty(equivalentTo: property) {
-        declarations.append(decl)
-      }
-    }
-  }
+	func addIfNeeded(_ decl: DeclSyntax?, to declarations: inout [DeclSyntax]) {
+		guard let decl else { return }
+		if let fn = decl.as(FunctionDeclSyntax.self) {
+			if !hasMemberFunction(equvalentTo: fn) {
+				declarations.append(decl)
+			}
+		} else if let property = decl.as(VariableDeclSyntax.self) {
+			if !hasMemberProperty(equivalentTo: property) {
+				declarations.append(decl)
+			}
+		}
+	}
 
-  var isClass: Bool {
-    return self.is(ClassDeclSyntax.self)
-  }
+	var isClass: Bool {
+		return self.is(ClassDeclSyntax.self)
+	}
 
-  var isActor: Bool {
-    return self.is(ActorDeclSyntax.self)
-  }
+	var isActor: Bool {
+		return self.is(ActorDeclSyntax.self)
+	}
 
-  var isEnum: Bool {
-    return self.is(EnumDeclSyntax.self)
-  }
+	var isEnum: Bool {
+		return self.is(EnumDeclSyntax.self)
+	}
 
-  var isStruct: Bool {
-    return self.is(StructDeclSyntax.self)
-  }
+	var isStruct: Bool {
+		return self.is(StructDeclSyntax.self)
+	}
 }

--- a/Sources/JSONAPIMacros/Helpers/Extensions.swift
+++ b/Sources/JSONAPIMacros/Helpers/Extensions.swift
@@ -2,116 +2,118 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension SyntaxStringInterpolation {
-  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
-    if let node = node {
-      appendInterpolation(node)
-    }
-  }
+	mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+		if let node = node {
+			appendInterpolation(node)
+		}
+	}
 }
 
 extension DeclGroupSyntax {
-  var publicModifier: DeclModifierSyntax? {
-    self.modifiers.first { modifier in
-      modifier.tokens(viewMode: .all).contains { token in
-        token.tokenKind == .keyword(.public)
-      }
-    }
-  }
+	var publicModifier: DeclModifierSyntax? {
+		self.modifiers.first { modifier in
+			modifier.tokens(viewMode: .all).contains { token in
+				token.tokenKind == .keyword(.public)
+			}
+		}
+	}
 }
 
 extension VariableDeclSyntax {
-  var isArray: Bool {
-    self.type?.isArray ?? false
-  }
+	var isArray: Bool {
+		self.type?.isArray ?? false
+	}
 
-  var isOptional: Bool {
-    self.type?.isOptional ?? false
-  }
+	var isOptional: Bool {
+		self.type?.isOptional ?? false
+	}
 
-  var optionalWrappedType: TypeSyntax? {
-    self.type?.optionalWrappedType
-  }
+	var optionalWrappedType: TypeSyntax? {
+		self.type?.optionalWrappedType
+	}
 
-  func attribute(named name: String) -> AttributeSyntax? {
-    for attribute in attributes {
-      switch attribute {
-      case .attribute(let attr):
-        if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [.identifier(name)] {
-          return attr
-        }
-      default:
-        return nil
-      }
-    }
-    return nil
-  }
+	func attribute(named name: String) -> AttributeSyntax? {
+		for attribute in attributes {
+			switch attribute {
+			case .attribute(let attr):
+				if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [
+					.identifier(name)
+				] {
+					return attr
+				}
+			default:
+				return nil
+			}
+		}
+		return nil
+	}
 }
 
 extension TypeSyntax {
-  var isArray: Bool {
-    // Check for shorthand array syntax ([Type])
-    if self.is(ArrayTypeSyntax.self) {
-      return true
-    }
+	var isArray: Bool {
+		// Check for shorthand array syntax ([Type])
+		if self.is(ArrayTypeSyntax.self) {
+			return true
+		}
 
-    // Check for Array<Element> syntax
-    if let identifierType = self.as(IdentifierTypeSyntax.self),
-      identifierType.name.text == "Array"
-    {
-      return true
-    }
+		// Check for Array<Element> syntax
+		if let identifierType = self.as(IdentifierTypeSyntax.self),
+			identifierType.name.text == "Array"
+		{
+			return true
+		}
 
-    return false
-  }
+		return false
+	}
 
-  var isOptional: Bool {
-    // Check for shorthand optional syntax (Type?)
-    if self.is(OptionalTypeSyntax.self) {
-      return true
-    }
+	var isOptional: Bool {
+		// Check for shorthand optional syntax (Type?)
+		if self.is(OptionalTypeSyntax.self) {
+			return true
+		}
 
-    // Check for Optional<Type> generic type syntax
-    if let identifierType = self.as(IdentifierTypeSyntax.self),
-      identifierType.name.text == "Optional"
-    {
-      return true
-    }
+		// Check for Optional<Type> generic type syntax
+		if let identifierType = self.as(IdentifierTypeSyntax.self),
+			identifierType.name.text == "Optional"
+		{
+			return true
+		}
 
-    return false
-  }
+		return false
+	}
 
-  var optionalWrappedType: TypeSyntax? {
-    // Check for shorthand optional syntax (Type?)
-    if let optionalType = self.as(OptionalTypeSyntax.self) {
-      return optionalType.wrappedType
-    }
+	var optionalWrappedType: TypeSyntax? {
+		// Check for shorthand optional syntax (Type?)
+		if let optionalType = self.as(OptionalTypeSyntax.self) {
+			return optionalType.wrappedType
+		}
 
-    // Check for Optional<Type> generic type syntax
-    if let identifierType = self.as(IdentifierTypeSyntax.self),
-      identifierType.name.text == "Optional",
-      let genericArgumentClause = identifierType.genericArgumentClause,
-      let firstArgument = genericArgumentClause.arguments.first
-    {
-      return firstArgument.argument
-    }
+		// Check for Optional<Type> generic type syntax
+		if let identifierType = self.as(IdentifierTypeSyntax.self),
+			identifierType.name.text == "Optional",
+			let genericArgumentClause = identifierType.genericArgumentClause,
+			let firstArgument = genericArgumentClause.arguments.first
+		{
+			return firstArgument.argument
+		}
 
-    return nil
-  }
+		return nil
+	}
 }
 
 extension AttributeSyntax {
-  var firstArgument: LabeledExprSyntax? {
-    guard case .argumentList(let arguments) = self.arguments else {
-      return nil
-    }
-    return arguments.first
-  }
+	var firstArgument: LabeledExprSyntax? {
+		guard case .argumentList(let arguments) = self.arguments else {
+			return nil
+		}
+		return arguments.first
+	}
 
-  var firstArgumentStringLiteral: StringLiteralExprSyntax? {
-    self.firstArgument?.expression.as(StringLiteralExprSyntax.self)
-  }
+	var firstArgumentStringLiteral: StringLiteralExprSyntax? {
+		self.firstArgument?.expression.as(StringLiteralExprSyntax.self)
+	}
 
-  var firstArgumentStringLiteralSegment: StringSegmentSyntax? {
-    self.firstArgumentStringLiteral?.segments.first?.as(StringSegmentSyntax.self)
-  }
+	var firstArgumentStringLiteralSegment: StringSegmentSyntax? {
+		self.firstArgumentStringLiteral?.segments.first?.as(StringSegmentSyntax.self)
+	}
 }

--- a/Sources/JSONAPIMacros/JSONAPIDiagnostic.swift
+++ b/Sources/JSONAPIMacros/JSONAPIDiagnostic.swift
@@ -2,52 +2,53 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 struct JSONAPIDiagnostic: DiagnosticMessage {
-  enum ID: String {
-    case invalidApplication = "invalid type"
-    case missingResourceType = "missing resource type"
-    case missingKey = "missing key"
-  }
+	enum ID: String {
+		case invalidApplication = "invalid type"
+		case missingResourceType = "missing resource type"
+		case missingKey = "missing key"
+	}
 
-  var message: String
-  var diagnosticID: MessageID
-  var severity: DiagnosticSeverity
+	var message: String
+	var diagnosticID: MessageID
+	var severity: DiagnosticSeverity
 
-  init(
-    message: String, diagnosticID: SwiftDiagnostics.MessageID,
-    severity: SwiftDiagnostics.DiagnosticSeverity = .error
-  ) {
-    self.message = message
-    self.diagnosticID = diagnosticID
-    self.severity = severity
-  }
+	init(
+		message: String, diagnosticID: SwiftDiagnostics.MessageID,
+		severity: SwiftDiagnostics.DiagnosticSeverity = .error
+	) {
+		self.message = message
+		self.diagnosticID = diagnosticID
+		self.severity = severity
+	}
 
-  init(
-    message: String,
-    domain: String,
-    id: ID,
-    severity: SwiftDiagnostics.DiagnosticSeverity = .error
-  ) {
-    self.message = message
-    self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
-    self.severity = severity
-  }
+	init(
+		message: String,
+		domain: String,
+		id: ID,
+		severity: SwiftDiagnostics.DiagnosticSeverity = .error
+	) {
+		self.message = message
+		self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
+		self.severity = severity
+	}
 }
 
 extension DiagnosticsError {
-  init<S: SyntaxProtocol>(
-    syntax: S,
-    message: String,
-    domain: String = "JSONAPI",
-    id: JSONAPIDiagnostic.ID,
-    severity: SwiftDiagnostics.DiagnosticSeverity = .error
-  ) {
-    self.init(
-      diagnostics: [
-        Diagnostic(
-          node: Syntax(syntax),
-          message: JSONAPIDiagnostic(message: message, domain: domain, id: id, severity: severity)
-        )
-      ]
-    )
-  }
+	init<S: SyntaxProtocol>(
+		syntax: S,
+		message: String,
+		domain: String = "JSONAPI",
+		id: JSONAPIDiagnostic.ID,
+		severity: SwiftDiagnostics.DiagnosticSeverity = .error
+	) {
+		self.init(
+			diagnostics: [
+				Diagnostic(
+					node: Syntax(syntax),
+					message: JSONAPIDiagnostic(
+						message: message, domain: domain, id: id, severity: severity)
+				)
+			]
+		)
+	}
 }

--- a/Sources/JSONAPIMacros/JSONAPIPlugin.swift
+++ b/Sources/JSONAPIMacros/JSONAPIPlugin.swift
@@ -3,9 +3,9 @@ import SwiftSyntaxMacros
 
 @main
 struct JSONAPIPlugin: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
-    CodableResourceMacro.self,
-    ResourceAttributeMacro.self,
-    ResourceRelationshipMacro.self,
-  ]
+	let providingMacros: [Macro.Type] = [
+		CodableResourceMacro.self,
+		ResourceAttributeMacro.self,
+		ResourceRelationshipMacro.self,
+	]
 }

--- a/Tests/JSONAPIMacrosTests/CodableResourceMacroTests.swift
+++ b/Tests/JSONAPIMacrosTests/CodableResourceMacroTests.swift
@@ -4,271 +4,271 @@ import SwiftSyntaxMacros
 import XCTest
 
 final class CodableResourceMacroTests: XCTestCase {
-  override func invokeTest() {
-    withMacroTesting(
-      // isRecording: true,
-      macros: [
-        CodableResourceMacro.self,
-        ResourceAttributeMacro.self,
-        ResourceRelationshipMacro.self,
-      ]
-    ) {
-      super.invokeTest()
-    }
-  }
+	override func invokeTest() {
+		withMacroTesting(
+			// isRecording: true,
+			macros: [
+				CodableResourceMacro.self,
+				ResourceAttributeMacro.self,
+				ResourceRelationshipMacro.self,
+			]
+		) {
+			super.invokeTest()
+		}
+	}
 
-  func testAttributes() {
-    assertMacro {
-      """
-      @CodableResource(type: "people")
-      struct Person {
-        var id: String
-        
-        @ResourceAttribute
-        var firstName: String
+	func testAttributes() {
+		assertMacro {
+			"""
+			@CodableResource(type: "people")
+			struct Person {
+			  var id: String
+			  
+			  @ResourceAttribute
+			  var firstName: String
 
-        @ResourceAttribute(key: "last_name")
-        var lastName: String
+			  @ResourceAttribute(key: "last_name")
+			  var lastName: String
 
-        @ResourceAttribute
-        var birthday: Date?
+			  @ResourceAttribute
+			  var birthday: Date?
 
-        @ResourceAttribute
-        var tags: [String]
-      }
-      """
-    } expansion: {
-      """
-      struct Person {
-        var id: String
-        
-        var firstName: String
-        var lastName: String
-        var birthday: Date?
-        var tags: [String]
+			  @ResourceAttribute
+			  var tags: [String]
+			}
+			"""
+		} expansion: {
+			"""
+			struct Person {
+			  var id: String
+			  
+			  var firstName: String
+			  var lastName: String
+			  var birthday: Date?
+			  var tags: [String]
 
-        static let type = "people"
-      }
+			  static let type = "people"
+			}
 
-      extension Person: JSONAPI.CodableResource {
-        private enum ResourceAttributeCodingKeys: String, CodingKey {
-            case firstName
-            case lastName = "last_name"
-            case birthday
-            case tags
-        }
+			extension Person: JSONAPI.CodableResource {
+			  private enum ResourceAttributeCodingKeys: String, CodingKey {
+			      case firstName
+			      case lastName = "last_name"
+			      case birthday
+			      case tags
+			  }
 
-        init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-            _ = try container.decode(ResourceType<Self>.self, forKey: .type)
-            self.id = try container.decode(String.self, forKey: .id)
-            let attributesContainer = try container.nestedContainer(keyedBy: ResourceAttributeCodingKeys.self, forKey: .attributes)
-            self.firstName = try attributesContainer.decode(String.self, forKey: .firstName)
-            self.lastName = try attributesContainer.decode(String.self, forKey: .lastName)
-            self.birthday = try attributesContainer.decodeIfPresent(Date.self, forKey: .birthday)
-            self.tags = try attributesContainer.decodeIfPresent([String].self, forKey: .tags) ?? []
-        }
-        func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-            try container.encode(Self.type, forKey: .type)
-            try container.encode(self.id, forKey: .id)
-            var attributesContainer = container.nestedContainer(keyedBy: ResourceAttributeCodingKeys.self, forKey: .attributes)
-            try attributesContainer.encode(self.firstName, forKey: .firstName)
-            try attributesContainer.encode(self.lastName, forKey: .lastName)
-            try attributesContainer.encodeIfPresent(self.birthday, forKey: .birthday)
-            try attributesContainer.encode(self.tags, forKey: .tags)
-        }
-      }
-      """
-    }
-  }
+			  init(from decoder: any Decoder) throws {
+			      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			      _ = try container.decode(ResourceType<Self>.self, forKey: .type)
+			      self.id = try container.decode(String.self, forKey: .id)
+			      let attributesContainer = try container.nestedContainer(keyedBy: ResourceAttributeCodingKeys.self, forKey: .attributes)
+			      self.firstName = try attributesContainer.decode(String.self, forKey: .firstName)
+			      self.lastName = try attributesContainer.decode(String.self, forKey: .lastName)
+			      self.birthday = try attributesContainer.decodeIfPresent(Date.self, forKey: .birthday)
+			      self.tags = try attributesContainer.decodeIfPresent([String].self, forKey: .tags) ?? []
+			  }
+			  func encode(to encoder: any Encoder) throws {
+			      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			      try container.encode(Self.type, forKey: .type)
+			      try container.encode(self.id, forKey: .id)
+			      var attributesContainer = container.nestedContainer(keyedBy: ResourceAttributeCodingKeys.self, forKey: .attributes)
+			      try attributesContainer.encode(self.firstName, forKey: .firstName)
+			      try attributesContainer.encode(self.lastName, forKey: .lastName)
+			      try attributesContainer.encodeIfPresent(self.birthday, forKey: .birthday)
+			      try attributesContainer.encode(self.tags, forKey: .tags)
+			  }
+			}
+			"""
+		}
+	}
 
-  func testRelationships() {
-    assertMacro {
-      """
-      @CodableResource(type: "articles")
-      struct Article {
-        @ResourceRelationship
-        var author: Person
+	func testRelationships() {
+		assertMacro {
+			"""
+			@CodableResource(type: "articles")
+			struct Article {
+			  @ResourceRelationship
+			  var author: Person
 
-        @ResourceRelationship
-        var coauthor: Person?
+			  @ResourceRelationship
+			  var coauthor: Person?
 
-        @ResourceRelationship
-        var comments: [Comment]
+			  @ResourceRelationship
+			  var comments: [Comment]
 
-        @ResourceRelationship(key: "related_articles")
-        var related: [Article]?
-      }
-      """
-    } expansion: {
-      """
-      struct Article {
-        var author: Person
-        var coauthor: Person?
-        var comments: [Comment]
-        var related: [Article]?
+			  @ResourceRelationship(key: "related_articles")
+			  var related: [Article]?
+			}
+			"""
+		} expansion: {
+			"""
+			struct Article {
+			  var author: Person
+			  var coauthor: Person?
+			  var comments: [Comment]
+			  var related: [Article]?
 
-        var id: String
+			  var id: String
 
-        static let type = "articles"
-      }
+			  static let type = "articles"
+			}
 
-      extension Article: JSONAPI.CodableResource {
+			extension Article: JSONAPI.CodableResource {
 
-        private enum ResourceRelationshipCodingKeys: String, CodingKey {
-            case author
-            case coauthor
-            case comments
-            case related = "related_articles"
-        }
-        init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-            _ = try container.decode(ResourceType<Self>.self, forKey: .type)
-            self.id = try container.decode(String.self, forKey: .id)
-            guard let includedResourceDecoder = decoder.includedResourceDecoder else {
-              throw DocumentDecodingError.includedResourceDecodingNotEnabled
-            }
-            let relationshipsContainer = try container.nestedContainer(keyedBy: ResourceRelationshipCodingKeys.self, forKey: .relationships)
-            let authorRelationship = try relationshipsContainer.decode(RelationshipToOne.self, forKey: .author)
-            self.author = try includedResourceDecoder.decode(Person.self, forRelationship: authorRelationship)
-            let coauthorRelationship = try relationshipsContainer.decodeIfPresent(OptionalRelationshipToOne.self, forKey: .coauthor)
-            self.coauthor = try includedResourceDecoder.decodeIfPresent(Person.self, forRelationship: coauthorRelationship)
-            let commentsRelationship = try relationshipsContainer.decode(RelationshipToMany.self, forKey: .comments)
-            self.comments = try includedResourceDecoder.decode([Comment].self, forRelationship: commentsRelationship)
-            let relatedRelationship = try relationshipsContainer.decodeIfPresent(RelationshipToMany.self, forKey: .related)
-            self.related = try includedResourceDecoder.decodeIfPresent([Article].self, forRelationship: relatedRelationship)
-        }
-        func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-            try container.encode(Self.type, forKey: .type)
-            try container.encode(self.id, forKey: .id)
-            guard let includedResourceEncoder = encoder.includedResourceEncoder else {
-              throw DocumentEncodingError.includedResourceEncodingNotEnabled
-            }
-            var relationshipsContainer = container.nestedContainer(keyedBy: ResourceRelationshipCodingKeys.self, forKey: .relationships)
-            try relationshipsContainer.encode(RelationshipToOne(resource: self.author), forKey: .author)
-            includedResourceEncoder.encode(self.author)
-            try relationshipsContainer.encodeIfPresent(RelationshipToOne(resource: self.coauthor), forKey: .coauthor)
-            includedResourceEncoder.encodeIfPresent(self.coauthor)
-            try relationshipsContainer.encode(RelationshipToMany(resources: self.comments), forKey: .comments)
-            includedResourceEncoder.encode(self.comments)
-            try relationshipsContainer.encodeIfPresent(RelationshipToMany(resources: self.related), forKey: .related)
-            includedResourceEncoder.encodeIfPresent(self.related)
-        }
-      }
-      """
-    }
-  }
+			  private enum ResourceRelationshipCodingKeys: String, CodingKey {
+			      case author
+			      case coauthor
+			      case comments
+			      case related = "related_articles"
+			  }
+			  init(from decoder: any Decoder) throws {
+			      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			      _ = try container.decode(ResourceType<Self>.self, forKey: .type)
+			      self.id = try container.decode(String.self, forKey: .id)
+			      guard let includedResourceDecoder = decoder.includedResourceDecoder else {
+			        throw DocumentDecodingError.includedResourceDecodingNotEnabled
+			      }
+			      let relationshipsContainer = try container.nestedContainer(keyedBy: ResourceRelationshipCodingKeys.self, forKey: .relationships)
+			      let authorRelationship = try relationshipsContainer.decode(RelationshipToOne.self, forKey: .author)
+			      self.author = try includedResourceDecoder.decode(Person.self, forRelationship: authorRelationship)
+			      let coauthorRelationship = try relationshipsContainer.decodeIfPresent(OptionalRelationshipToOne.self, forKey: .coauthor)
+			      self.coauthor = try includedResourceDecoder.decodeIfPresent(Person.self, forRelationship: coauthorRelationship)
+			      let commentsRelationship = try relationshipsContainer.decode(RelationshipToMany.self, forKey: .comments)
+			      self.comments = try includedResourceDecoder.decode([Comment].self, forRelationship: commentsRelationship)
+			      let relatedRelationship = try relationshipsContainer.decodeIfPresent(RelationshipToMany.self, forKey: .related)
+			      self.related = try includedResourceDecoder.decodeIfPresent([Article].self, forRelationship: relatedRelationship)
+			  }
+			  func encode(to encoder: any Encoder) throws {
+			      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			      try container.encode(Self.type, forKey: .type)
+			      try container.encode(self.id, forKey: .id)
+			      guard let includedResourceEncoder = encoder.includedResourceEncoder else {
+			        throw DocumentEncodingError.includedResourceEncodingNotEnabled
+			      }
+			      var relationshipsContainer = container.nestedContainer(keyedBy: ResourceRelationshipCodingKeys.self, forKey: .relationships)
+			      try relationshipsContainer.encode(RelationshipToOne(resource: self.author), forKey: .author)
+			      includedResourceEncoder.encode(self.author)
+			      try relationshipsContainer.encodeIfPresent(RelationshipToOne(resource: self.coauthor), forKey: .coauthor)
+			      includedResourceEncoder.encodeIfPresent(self.coauthor)
+			      try relationshipsContainer.encode(RelationshipToMany(resources: self.comments), forKey: .comments)
+			      includedResourceEncoder.encode(self.comments)
+			      try relationshipsContainer.encodeIfPresent(RelationshipToMany(resources: self.related), forKey: .related)
+			      includedResourceEncoder.encodeIfPresent(self.related)
+			  }
+			}
+			"""
+		}
+	}
 
-  func testAccessControl() {
-    assertMacro {
-      """
-      @CodableResource(type: "people")
-      public struct Person {
-      }
-      """
-    } expansion: {
-      """
-      public struct Person {
+	func testAccessControl() {
+		assertMacro {
+			"""
+			@CodableResource(type: "people")
+			public struct Person {
+			}
+			"""
+		} expansion: {
+			"""
+			public struct Person {
 
-          public var id: String
+			    public var id: String
 
-          public static let type = "people"
-      }
+			    public static let type = "people"
+			}
 
-      extension Person: JSONAPI.CodableResource {
-
-
-
-        public init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-            _ = try container.decode(ResourceType<Self>.self, forKey: .type)
-            self.id = try container.decode(String.self, forKey: .id)
-        }
-
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-            try container.encode(Self.type, forKey: .type)
-            try container.encode(self.id, forKey: .id)
-        }
-      }
-      """
-    }
-  }
-
-  func testRedundancy() {
-    assertMacro {
-      """
-      @CodableResource(type: "people")
-      struct Person {
-        typealias Id = Tagged<Person, String>
-
-        var id: Id
-      }
-      """
-    } expansion: {
-      """
-      struct Person {
-        typealias Id = Tagged<Person, String>
-
-        var id: Id
-
-        static let type = "people"
-      }
-
-      extension Person: JSONAPI.CodableResource {
+			extension Person: JSONAPI.CodableResource {
 
 
-        init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-            _ = try container.decode(ResourceType<Self>.self, forKey: .type)
-            self.id = try container.decode(Id.self, forKey: .id)
-        }
-        func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-            try container.encode(Self.type, forKey: .type)
-            try container.encode(self.id, forKey: .id)
-        }
-      }
-      """
-    }
-  }
 
-  func testAvailability() {
-    assertMacro {
-      """
-      @available(macOS, unavailable)
-      @CodableResource(type: "people")
-      struct Person {
-      }
-      """
-    } expansion: {
-      """
-      @available(macOS, unavailable)
-      struct Person {
+			  public init(from decoder: any Decoder) throws {
+			      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			      _ = try container.decode(ResourceType<Self>.self, forKey: .type)
+			      self.id = try container.decode(String.self, forKey: .id)
+			  }
 
-          var id: String
+			  public func encode(to encoder: any Encoder) throws {
+			      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			      try container.encode(Self.type, forKey: .type)
+			      try container.encode(self.id, forKey: .id)
+			  }
+			}
+			"""
+		}
+	}
 
-          static let type = "people"
-      }
+	func testRedundancy() {
+		assertMacro {
+			"""
+			@CodableResource(type: "people")
+			struct Person {
+			  typealias Id = Tagged<Person, String>
 
-      @available(macOS, unavailable)
-      extension Person: JSONAPI.CodableResource {
+			  var id: Id
+			}
+			"""
+		} expansion: {
+			"""
+			struct Person {
+			  typealias Id = Tagged<Person, String>
+
+			  var id: Id
+
+			  static let type = "people"
+			}
+
+			extension Person: JSONAPI.CodableResource {
 
 
-        init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
-            _ = try container.decode(ResourceType<Self>.self, forKey: .type)
-            self.id = try container.decode(String.self, forKey: .id)
-        }
-        func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: ResourceCodingKeys.self)
-            try container.encode(Self.type, forKey: .type)
-            try container.encode(self.id, forKey: .id)
-        }
-      }
-      """
-    }
-  }
+			  init(from decoder: any Decoder) throws {
+			      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			      _ = try container.decode(ResourceType<Self>.self, forKey: .type)
+			      self.id = try container.decode(Id.self, forKey: .id)
+			  }
+			  func encode(to encoder: any Encoder) throws {
+			      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			      try container.encode(Self.type, forKey: .type)
+			      try container.encode(self.id, forKey: .id)
+			  }
+			}
+			"""
+		}
+	}
+
+	func testAvailability() {
+		assertMacro {
+			"""
+			@available(macOS, unavailable)
+			@CodableResource(type: "people")
+			struct Person {
+			}
+			"""
+		} expansion: {
+			"""
+			@available(macOS, unavailable)
+			struct Person {
+
+			    var id: String
+
+			    static let type = "people"
+			}
+
+			@available(macOS, unavailable)
+			extension Person: JSONAPI.CodableResource {
+
+
+			  init(from decoder: any Decoder) throws {
+			      let container = try decoder.container(keyedBy: ResourceCodingKeys.self)
+			      _ = try container.decode(ResourceType<Self>.self, forKey: .type)
+			      self.id = try container.decode(String.self, forKey: .id)
+			  }
+			  func encode(to encoder: any Encoder) throws {
+			      var container = encoder.container(keyedBy: ResourceCodingKeys.self)
+			      try container.encode(Self.type, forKey: .type)
+			      try container.encode(self.id, forKey: .id)
+			  }
+			}
+			"""
+		}
+	}
 }

--- a/Tests/JSONAPITests/CodableResourceTests.swift
+++ b/Tests/JSONAPITests/CodableResourceTests.swift
@@ -2,329 +2,329 @@ import JSONAPI
 import XCTest
 
 final class CodableResourceTests: XCTestCase {
-  func testDecoding() throws {
-    // given
-    let json = """
-      {
-        "data": [
-          {
-            "type": "articles",
-            "id": "1",
-            "attributes": {
-              "title": "JSON:API paints my bikeshed!"
-            },
-            "relationships": {
-              "author": {
-                "data": {
-                  "type": "people",
-                  "id": "9"
-                }
-              },
-              "comments": {
-                "data": [
-                  {
-                    "type": "comments",
-                    "id": "5"
-                  },
-                  {
-                    "type": "comments",
-                    "id": "12"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "included": [
-          {
-            "type": "people",
-            "id": "9",
-            "attributes": {
-              "firstName": "Dan",
-              "lastName": "Gebhardt",
-              "twitter": "dgeb"
-            }
-          },
-          {
-            "type": "comments",
-            "id": "5",
-            "attributes": {
-              "body": "First!"
-            },
-            "relationships": {
-              "author": {
-                "data": {
-                  "type": "people",
-                  "id": "2"
-                }
-              }
-            }
-          },
-          {
-            "type": "people",
-            "id": "9",
-            "attributes": {
-              "firstName": "Dan",
-              "lastName": "Gebhardt",
-              "twitter": "dgeb"
-            }
-          },
-          {
-            "type": "comments",
-            "id": "12",
-            "attributes": {
-              "body": "I like XML better"
-            },
-            "relationships": {
-              "author": {
-                "data": {
-                  "type": "people",
-                  "id": "9"
-                }
-              }
-            }
-          }
-        ]
-      }
-      """.data(using: .utf8)!
+	func testDecoding() throws {
+		// given
+		let json = """
+			{
+			  "data": [
+			    {
+			      "type": "articles",
+			      "id": "1",
+			      "attributes": {
+			        "title": "JSON:API paints my bikeshed!"
+			      },
+			      "relationships": {
+			        "author": {
+			          "data": {
+			            "type": "people",
+			            "id": "9"
+			          }
+			        },
+			        "comments": {
+			          "data": [
+			            {
+			              "type": "comments",
+			              "id": "5"
+			            },
+			            {
+			              "type": "comments",
+			              "id": "12"
+			            }
+			          ]
+			        }
+			      }
+			    }
+			  ],
+			  "included": [
+			    {
+			      "type": "people",
+			      "id": "9",
+			      "attributes": {
+			        "firstName": "Dan",
+			        "lastName": "Gebhardt",
+			        "twitter": "dgeb"
+			      }
+			    },
+			    {
+			      "type": "comments",
+			      "id": "5",
+			      "attributes": {
+			        "body": "First!"
+			      },
+			      "relationships": {
+			        "author": {
+			          "data": {
+			            "type": "people",
+			            "id": "2"
+			          }
+			        }
+			      }
+			    },
+			    {
+			      "type": "people",
+			      "id": "9",
+			      "attributes": {
+			        "firstName": "Dan",
+			        "lastName": "Gebhardt",
+			        "twitter": "dgeb"
+			      }
+			    },
+			    {
+			      "type": "comments",
+			      "id": "12",
+			      "attributes": {
+			        "body": "I like XML better"
+			      },
+			      "relationships": {
+			        "author": {
+			          "data": {
+			            "type": "people",
+			            "id": "9"
+			          }
+			        }
+			      }
+			    }
+			  ]
+			}
+			""".data(using: .utf8)!
 
-    // when
-    let articles = try JSONDecoder().decode([Article].self, from: json)
+		// when
+		let articles = try JSONDecoder().decode([Article].self, from: json)
 
-    // then
-    XCTAssertEqual(
-      [
-        Article(
-          id: "1",
-          title: "JSON:API paints my bikeshed!",
-          author: Person(
-            id: "9",
-            firstName: "Dan",
-            lastName: "Gebhardt",
-            twitter: "dgeb"
-          ),
-          comments: [
-            Comment(id: "5", body: "First!"),
-            Comment(
-              id: "12",
-              body: "I like XML better",
-              author: Person(
-                id: "9",
-                firstName: "Dan",
-                lastName: "Gebhardt",
-                twitter: "dgeb"
-              )
-            ),
-          ]
-        )
-      ],
-      articles
-    )
-  }
+		// then
+		XCTAssertEqual(
+			[
+				Article(
+					id: "1",
+					title: "JSON:API paints my bikeshed!",
+					author: Person(
+						id: "9",
+						firstName: "Dan",
+						lastName: "Gebhardt",
+						twitter: "dgeb"
+					),
+					comments: [
+						Comment(id: "5", body: "First!"),
+						Comment(
+							id: "12",
+							body: "I like XML better",
+							author: Person(
+								id: "9",
+								firstName: "Dan",
+								lastName: "Gebhardt",
+								twitter: "dgeb"
+							)
+						),
+					]
+				)
+			],
+			articles
+		)
+	}
 
-  func testDecodeNull() throws {
-    // given
-    let json = """
-      {
-        "data": null
-      }
-      """.data(using: .utf8)!
+	func testDecodeNull() throws {
+		// given
+		let json = """
+			{
+			  "data": null
+			}
+			""".data(using: .utf8)!
 
-    // when
-    let articles = try JSONDecoder().decode([Article].self, from: json)
+		// when
+		let articles = try JSONDecoder().decode([Article].self, from: json)
 
-    // then
-    XCTAssertEqual([], articles)
-  }
+		// then
+		XCTAssertEqual([], articles)
+	}
 
-  func testDecodeNullRelationshipToMany() throws {
-    // given
-    let json = """
-      {
-        "data": [
-          {
-            "type": "articles",
-            "id": "1",
-            "attributes": {
-              "title": "JSON:API paints my bikeshed!"
-            },
-            "relationships": {
-              "author": {
-                "data": {
-                  "type": "people",
-                  "id": "9"
-                }
-              },
-              "comments": {
-                "data": null
-              }
-            }
-          }
-        ],
-        "included": [
-          {
-            "type": "people",
-            "id": "9",
-            "attributes": {
-              "firstName": "Dan",
-              "lastName": "Gebhardt",
-              "twitter": "dgeb"
-            }
-          }
-        ]
-      }
-      """.data(using: .utf8)!
+	func testDecodeNullRelationshipToMany() throws {
+		// given
+		let json = """
+			{
+			  "data": [
+			    {
+			      "type": "articles",
+			      "id": "1",
+			      "attributes": {
+			        "title": "JSON:API paints my bikeshed!"
+			      },
+			      "relationships": {
+			        "author": {
+			          "data": {
+			            "type": "people",
+			            "id": "9"
+			          }
+			        },
+			        "comments": {
+			          "data": null
+			        }
+			      }
+			    }
+			  ],
+			  "included": [
+			    {
+			      "type": "people",
+			      "id": "9",
+			      "attributes": {
+			        "firstName": "Dan",
+			        "lastName": "Gebhardt",
+			        "twitter": "dgeb"
+			      }
+			    }
+			  ]
+			}
+			""".data(using: .utf8)!
 
-    // when
-    let articles = try JSONDecoder().decode([Article].self, from: json)
+		// when
+		let articles = try JSONDecoder().decode([Article].self, from: json)
 
-    // then
-    XCTAssertEqual(
-      [
-        Article(
-          id: "1",
-          title: "JSON:API paints my bikeshed!",
-          author: Person(
-            id: "9",
-            firstName: "Dan",
-            lastName: "Gebhardt",
-            twitter: "dgeb"
-          ),
-          comments: []
-        )
-      ],
-      articles
-    )
-  }
+		// then
+		XCTAssertEqual(
+			[
+				Article(
+					id: "1",
+					title: "JSON:API paints my bikeshed!",
+					author: Person(
+						id: "9",
+						firstName: "Dan",
+						lastName: "Gebhardt",
+						twitter: "dgeb"
+					),
+					comments: []
+				)
+			],
+			articles
+		)
+	}
 
-  func testNullRelationshipToOne() throws {
-    // given
-    let json = """
-      {
-        "data": {
-          "type": "comments",
-          "id": "12",
-          "attributes": {
-            "body": "I like XML better"
-          },
-          "relationships": {
-            "author": {
-              "data": null
-            }
-          }
-        }
-      }
-      """.data(using: .utf8)!
+	func testNullRelationshipToOne() throws {
+		// given
+		let json = """
+			{
+			  "data": {
+			    "type": "comments",
+			    "id": "12",
+			    "attributes": {
+			      "body": "I like XML better"
+			    },
+			    "relationships": {
+			      "author": {
+			        "data": null
+			      }
+			    }
+			  }
+			}
+			""".data(using: .utf8)!
 
-    // when
-    let comment = try JSONDecoder().decode(Comment.self, from: json)
+		// when
+		let comment = try JSONDecoder().decode(Comment.self, from: json)
 
-    // then
-    XCTAssertEqual(
-      Comment(id: "12", body: "I like XML better"),
-      comment
-    )
-  }
+		// then
+		XCTAssertEqual(
+			Comment(id: "12", body: "I like XML better"),
+			comment
+		)
+	}
 
-  func testDecodeNullArrayAttribute() throws {
-    // given
-    let json = """
-      {
-        "data": [
-          {
-            "type": "schedules",
-            "id": "1",
-            "attributes": {
-              "name": "Some schedule",
-              "tags": [
-                "some tag"
-              ]
-            }
-          },
-          {
-            "type": "schedules",
-            "id": "2",
-            "attributes": {
-              "name": "Some other schedule",
-              "tags": null
-            }
-          }
-        ]
-      }
-      """.data(using: .utf8)!
+	func testDecodeNullArrayAttribute() throws {
+		// given
+		let json = """
+			{
+			  "data": [
+			    {
+			      "type": "schedules",
+			      "id": "1",
+			      "attributes": {
+			        "name": "Some schedule",
+			        "tags": [
+			          "some tag"
+			        ]
+			      }
+			    },
+			    {
+			      "type": "schedules",
+			      "id": "2",
+			      "attributes": {
+			        "name": "Some other schedule",
+			        "tags": null
+			      }
+			    }
+			  ]
+			}
+			""".data(using: .utf8)!
 
-    // when
-    let schedules = try JSONDecoder().decode([Schedule].self, from: json)
+		// when
+		let schedules = try JSONDecoder().decode([Schedule].self, from: json)
 
-    // then
-    XCTAssertEqual(
-      [
-        Schedule(id: "1", name: "Some schedule", tags: ["some tag"]),
-        Schedule(id: "2", name: "Some other schedule", tags: []),
-      ],
-      schedules
-    )
-  }
+		// then
+		XCTAssertEqual(
+			[
+				Schedule(id: "1", name: "Some schedule", tags: ["some tag"]),
+				Schedule(id: "2", name: "Some other schedule", tags: []),
+			],
+			schedules
+		)
+	}
 
-  func testEncodingRoundtrip() throws {
-    // given
-    let articles: [Article] = [
-      Article(
-        id: "1",
-        title: "Assure polite his really and others figure though",
-        author: Person(
-          id: "10",
-          firstName: "Guille",
-          lastName: "González"
-        ),
-        comments: [
-          Comment(
-            id: "20",
-            body: "Game of as rest time eyes with of this it.",
-            author: Person(
-              id: "11",
-              firstName: "Yassir",
-              lastName: "Ramdani"
-            )
-          ),
-          Comment(
-            id: "21",
-            body: "Add was music merry any truth since going.",
-            author: Person(
-              id: "12",
-              firstName: "Alan",
-              lastName: "Fineberg"
-            )
-          ),
-        ]
-      ),
-      Article(
-        id: "2",
-        title: "Procuring education on consulted assurance in do",
-        author: Person(
-          id: "11",
-          firstName: "Yassir",
-          lastName: "Ramdani"
-        ),
-        comments: [
-          Comment(
-            id: "22",
-            body: "Is sympathize he expression mr no travelling",
-            author: Person(
-              id: "10",
-              firstName: "Guille",
-              lastName: "González"
-            )
-          )
-        ]
-      ),
-    ]
+	func testEncodingRoundtrip() throws {
+		// given
+		let articles: [Article] = [
+			Article(
+				id: "1",
+				title: "Assure polite his really and others figure though",
+				author: Person(
+					id: "10",
+					firstName: "Guille",
+					lastName: "González"
+				),
+				comments: [
+					Comment(
+						id: "20",
+						body: "Game of as rest time eyes with of this it.",
+						author: Person(
+							id: "11",
+							firstName: "Yassir",
+							lastName: "Ramdani"
+						)
+					),
+					Comment(
+						id: "21",
+						body: "Add was music merry any truth since going.",
+						author: Person(
+							id: "12",
+							firstName: "Alan",
+							lastName: "Fineberg"
+						)
+					),
+				]
+			),
+			Article(
+				id: "2",
+				title: "Procuring education on consulted assurance in do",
+				author: Person(
+					id: "11",
+					firstName: "Yassir",
+					lastName: "Ramdani"
+				),
+				comments: [
+					Comment(
+						id: "22",
+						body: "Is sympathize he expression mr no travelling",
+						author: Person(
+							id: "10",
+							firstName: "Guille",
+							lastName: "González"
+						)
+					)
+				]
+			),
+		]
 
-    // when
-    let data = try JSONEncoder().encode(articles)
-    let decodedArticles = try JSONDecoder().decode([Article].self, from: data)
+		// when
+		let data = try JSONEncoder().encode(articles)
+		let decodedArticles = try JSONDecoder().decode([Article].self, from: data)
 
-    // then
-    XCTAssertEqual(decodedArticles, articles)
-  }
+		// then
+		XCTAssertEqual(decodedArticles, articles)
+	}
 }

--- a/Tests/JSONAPITests/Models.swift
+++ b/Tests/JSONAPITests/Models.swift
@@ -2,75 +2,75 @@ import Foundation
 import JSONAPI
 
 struct PersonID: Hashable {
-  var rawValue: String
+	var rawValue: String
 
-  init(rawValue: String) {
-    self.rawValue = rawValue
-  }
+	init(rawValue: String) {
+		self.rawValue = rawValue
+	}
 }
 
 extension PersonID: RawRepresentable {}
 extension PersonID: Codable {}
 
 extension PersonID: CustomStringConvertible {
-  var description: String {
-    rawValue.description
-  }
+	var description: String {
+		rawValue.description
+	}
 }
 
 extension PersonID: ExpressibleByStringLiteral {
-  init(stringLiteral value: String.StringLiteralType) {
-    self.init(rawValue: String(stringLiteral: value))
-  }
+	init(stringLiteral value: String.StringLiteralType) {
+		self.init(rawValue: String(stringLiteral: value))
+	}
 }
 
 @CodableResource(type: "people")
 struct Person: Equatable {
-  // Exercise a tagged type instead of a string
-  var id: PersonID
+	// Exercise a tagged type instead of a string
+	var id: PersonID
 
-  @ResourceAttribute
-  var firstName: String
+	@ResourceAttribute
+	var firstName: String
 
-  @ResourceAttribute
-  var lastName: String
+	@ResourceAttribute
+	var lastName: String
 
-  @ResourceAttribute
-  var twitter: String?
+	@ResourceAttribute
+	var twitter: String?
 }
 
 @CodableResource(type: "comments")
 struct Comment: Equatable {
-  var id: String
+	var id: String
 
-  @ResourceAttribute
-  var body: String
+	@ResourceAttribute
+	var body: String
 
-  @ResourceRelationship
-  var author: Person?
+	@ResourceRelationship
+	var author: Person?
 }
 
 @CodableResource(type: "articles")
 struct Article: Equatable {
-  var id: String
+	var id: String
 
-  @ResourceAttribute
-  var title: String
+	@ResourceAttribute
+	var title: String
 
-  @ResourceRelationship
-  var author: Person
+	@ResourceRelationship
+	var author: Person
 
-  @ResourceRelationship
-  var comments: [Comment]
+	@ResourceRelationship
+	var comments: [Comment]
 }
 
 @CodableResource(type: "schedules")
 struct Schedule: Equatable {
-  var id: String
+	var id: String
 
-  @ResourceAttribute
-  var name: String
+	@ResourceAttribute
+	var name: String
 
-  @ResourceAttribute
-  var tags: [String]
+	@ResourceAttribute
+	var tags: [String]
 }


### PR DESCRIPTION
This pull request fixes code formatting both on the library and on the macro generated code by doing the following:

- Add a `.swift-format` configuration file that matches the rules we have for other projects: tab indentation, 120 line length, etc.
- Run `make format` to format the library code.
- Remove explicit indentation in the macro generated code, letting Xcode to format the code based on the editor rules.
- Update macro snapshot tests