### PR TITLE
Document level `meta` information

### DIFF
--- a/Sources/JSONAPI/JSONAPIDecoder.swift
+++ b/Sources/JSONAPI/JSONAPIDecoder.swift
@@ -17,14 +17,23 @@ public class JSONAPIDecoder: JSONDecoder {
 	}
 
 	public func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: DecodableResource {
-		try self.decode(Document<T>.self, from: data).data
+		try self.decode(Document<T, Unit>.self, from: data).data
 	}
 
 	public func decode<T>(
 		_ type: T.Type,
 		from data: Data
 	) throws -> T where T: RangeReplaceableCollection, T: Decodable, T.Element: DecodableResource {
-		try self.decode(Document<T?>.self, from: data).data ?? T()
+		try self.decode(Document<T?, Unit>.self, from: data).data ?? T()
+	}
+
+	public func decode<T, Meta>(
+		_ type: Document<T, Meta>.Type,
+		from data: Data
+	) throws -> Document<T, Meta>
+	where T: RangeReplaceableCollection, T: Decodable, T.Element: DecodableResource, Meta: Decodable {
+		let document = try self.decode(Document<T?, Meta>.self, from: data)
+		return Document(data: document.data ?? T(), meta: document.meta)
 	}
 }
 

--- a/Sources/JSONAPI/Unit.swift
+++ b/Sources/JSONAPI/Unit.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public struct Unit: Equatable, Codable {}

--- a/Tests/JSONAPITests/Models.swift
+++ b/Tests/JSONAPITests/Models.swift
@@ -127,3 +127,8 @@ struct SingleAttachmentMessage: Equatable {
 	@ResourceRelationship
 	var attachment: Attachment?
 }
+
+struct CopyrightInfo: Equatable, Codable {
+	var copyright: String
+	var authors: [String]
+}


### PR DESCRIPTION
### TL;DR
Add JSON:API top-level `meta` information.

### Context
This pull request allows clients to define a type that will be used to decode or encode top-level `meta` information. The main use case in Datadog is pagination information.

### Summary of Changes
- Add a new terminal type called `Unit` as an alternative to `Void`. This new type conforms to `Equatable` and `Codable` and can be used when `Document` does not have `meta` information.
- Add a new `Meta` type parameter to `Document` and update the `Codable` implementation.
- Add test cases

### How to Test
This pull request includes unit tests that exercise all the changes.