### PR TITLE
Fix array attribute missing space

### DIFF
--- a/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
+++ b/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
@@ -284,6 +284,7 @@ extension StructDeclSyntax {
 				try StructDeclSyntax.makeDefinitionAttributes(
 					arrayAttributes: AttributeListSyntax {
 						AttributeSyntax("@DefaultEmpty")
+							.with(\.trailingTrivia, .space)
 					},
 					modifiers: modifiers,
 					inheritedTypeList: inheritedTypeList,

--- a/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
+++ b/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
@@ -420,17 +420,15 @@ final class ResourceWrapperMacroTests: XCTestCase {
 			struct Schedule: Equatable {
 				var id: UUID
 
-				@ResourceAttribute
-				var name: String
-
-				@ResourceAttribute
-				var tags: [String]
+				@ResourceAttribute var name: String
+				@ResourceAttribute var tags: [String]
 			}
 			"""
 		} expansion: {
 			"""
 			struct Schedule: Equatable {
 				var id: UUID
+
 				var name: String
 				var tags: [String]
 			}
@@ -439,15 +437,13 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var name: String
-						@DefaultEmpty
-							var tags: [String]
+						@DefaultEmpty var tags: [String]
 					}
 					static let resourceType = "schedules"
 				}
 				struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var name: String?
-
 						var tags: [String]?
 					}
 					static let resourceType = Definition.resourceType


### PR DESCRIPTION
### TL;DR
Add a trailing space to `@DefaultEmpty` attribute when generating the code for an array `@ResourceAttribute` property.

### Context
Fixes #10. See the issue description for a detailed explanation.