### PR TITLE
Update `swift-syntax` and `swift-macro-testing` dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "90e38eec4bf661ec0da1bbfd3ec507d0f0c05310",
-        "version" : "0.3.0"
+        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
+        "version" : "0.5.2"
       }
     },
     {
@@ -32,14 +32,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "5b0c434778f2c1a4c9b5ebdb8682b28e84dd69bd",
-        "version" : "1.15.4"
+        "revision" : "6d932a79e7173b275b96c600c86c603cf84f153c",
+        "version" : "1.17.4"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
-		.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
+		.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"511.0.0"),
+		.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
 		.package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
 	],


### PR DESCRIPTION
### TL;DR
Update `swift-syntax` and `swift-macro-testing` dependencies.

### Context
Apple recently moved Swift open source repositories to a new `SwiftLang` organization in GitHub. This is causing a collision warning in SPM when two packages depend on the same repository (`swift-syntax`) but pointing to different organizations.