### PR TITLE
Throw an error when the resource encoder / decoder cannot be found

### DIFF
--- a/Sources/JSONAPI/InlineRelationshipMany.swift
+++ b/Sources/JSONAPI/InlineRelationshipMany.swift
@@ -53,7 +53,7 @@ extension InlineRelationshipMany: Decodable where Destination: Decodable {
 		let data = try container.decodeIfPresent([ResourceIdentifier].self, forKey: .data) ?? []
 
 		guard let resourceDecoder = decoder.resourceDecoder else {
-			fatalError("You must use a 'JSONAPIDecoder' instance to decode a JSON:API response.")
+			throw JSONAPIDecodingError.resourceDecoderNotFound
 		}
 
 		self.resources = try resourceDecoder.decode([Destination].self, identifiers: data)
@@ -68,7 +68,7 @@ extension InlineRelationshipMany: Encodable where Destination: Encodable & Resou
 		try container.encode(data, forKey: .data)
 
 		guard let resourceEncoder = encoder.resourceEncoder else {
-			fatalError("You must use a 'JSONAPIEncoder' instance to encode a JSON:API resource.")
+			throw JSONAPIEncodingError.resourceEncoderNotFound
 		}
 
 		resourceEncoder.encode(self.resources)

--- a/Sources/JSONAPI/InlineRelationshipOne.swift
+++ b/Sources/JSONAPI/InlineRelationshipOne.swift
@@ -33,7 +33,7 @@ extension InlineRelationshipOne: Decodable where Destination: Decodable {
 		let data = try container.decode(ResourceIdentifier.self, forKey: .data)
 
 		guard let resourceDecoder = decoder.resourceDecoder else {
-			fatalError("You must use a 'JSONAPIDecoder' instance to decode a JSON:API response.")
+			throw JSONAPIDecodingError.resourceDecoderNotFound
 		}
 
 		self.resource = try resourceDecoder.decode(Destination.self, identifier: data)
@@ -48,7 +48,7 @@ extension InlineRelationshipOne: Encodable where Destination: Encodable & Resour
 		try container.encode(data, forKey: .data)
 
 		guard let resourceEncoder = encoder.resourceEncoder else {
-			fatalError("You must use a 'JSONAPIEncoder' instance to encode a JSON:API resource.")
+			throw JSONAPIEncodingError.resourceEncoderNotFound
 		}
 
 		resourceEncoder.encode(self.resource)

--- a/Sources/JSONAPI/InlineRelationshipOptional.swift
+++ b/Sources/JSONAPI/InlineRelationshipOptional.swift
@@ -33,7 +33,7 @@ extension InlineRelationshipOptional: Decodable where Destination: Decodable {
 
 		if let data = try container.decodeIfPresent(ResourceIdentifier.self, forKey: .data) {
 			guard let resourceDecoder = decoder.resourceDecoder else {
-				fatalError("You must use a 'JSONAPIDecoder' instance to decode a JSON:API response.")
+				throw JSONAPIDecodingError.resourceDecoderNotFound
 			}
 
 			self.resource = try resourceDecoder.decodeIfPresent(Destination.self, identifier: data)
@@ -52,7 +52,7 @@ extension InlineRelationshipOptional: Encodable where Destination: Encodable, De
 		try container.encode(data, forKey: .data)
 
 		guard let resourceEncoder = encoder.resourceEncoder else {
-			fatalError("You must use a 'JSONAPIEncoder' instance to encode a JSON:API resource.")
+			throw JSONAPIEncodingError.resourceEncoderNotFound
 		}
 
 		resourceEncoder.encodeIfPresent(self.resource)

--- a/Sources/JSONAPI/JSONAPIDecoder.swift
+++ b/Sources/JSONAPI/JSONAPIDecoder.swift
@@ -101,6 +101,8 @@ public class JSONAPIDecoder: JSONDecoder {
 	}
 }
 
+extension JSONAPIDecoder: @unchecked Sendable {}
+
 extension Decoder {
 	var resourceDecoder: ResourceDecoder? {
 		self.userInfo.resourceDecoderStorage?.resourceDecoder

--- a/Sources/JSONAPI/JSONAPIDecodingError.swift
+++ b/Sources/JSONAPI/JSONAPIDecodingError.swift
@@ -13,4 +13,10 @@ public enum JSONAPIDecodingError: Error {
 	///
 	/// As associated values this case contains the union type and the unhandled resource type string.
 	case unhandledResourceType(any Any.Type, String)
+
+	/// Indicates that the decoder couldn't find the associated resource decoder.
+	///
+	/// This error typically happens when trying to decode a JSON:API response using a `JSONDecoder`
+	/// instead of a ``JSONAPIDecoder``.
+	case resourceDecoderNotFound
 }

--- a/Sources/JSONAPI/JSONAPIEncoder.swift
+++ b/Sources/JSONAPI/JSONAPIEncoder.swift
@@ -113,6 +113,8 @@ public class JSONAPIEncoder: JSONEncoder {
 	}
 }
 
+extension JSONAPIEncoder: @unchecked Sendable {}
+
 extension Encoder {
 	var resourceEncoder: ResourceEncoder? {
 		self.userInfo.resourceEncoder

--- a/Sources/JSONAPI/JSONAPIEncodingError.swift
+++ b/Sources/JSONAPI/JSONAPIEncodingError.swift
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under
+// the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+import Foundation
+
+/// An error that occurs during the encoding of a JSON:API document.
+public enum JSONAPIEncodingError: Error {
+	/// Indicates that the encoder couldn't find the associated resource encoder.
+	///
+	/// This error typically happens when trying to encode a JSON:API resource using a `JSONEncoder`
+	/// instead of a ``JSONAPIEncoder``.
+	case resourceEncoderNotFound
+}


### PR DESCRIPTION
### TL;DR
Throw an error when the resource encoder / decoder cannot be found instead of a `fatalError`.

### Context
There are some situations in which this can happen without being a programmer error (ie. not using `JSONAPIEncoder` or `JSONAPIDecoder`).

### Summary of Changes
- Throw an specific error instead of using `fatalError` when the resource encoder or decoder cannot be found
- Restate the `@unchecked Sendable` inherited conformance in `JSONAPIEncoder` and `JSONAPIDecoder`.

### How to Test
N/A

### Demo
N/A
