### PR TITLE
Add empty-to-one `decode` method

### DIFF
--- a/Sources/JSONAPI/JSONAPIDecoder.swift
+++ b/Sources/JSONAPI/JSONAPIDecoder.swift
@@ -82,6 +82,10 @@ public class JSONAPIDecoder: JSONDecoder {
 		try self.decode(CompoundDocument<R, Unit>.self, from: data).data
 	}
 
+	public func decode<R>(_: R?.Type, from data: Data) throws -> R? where R: ResourceIdentifiable & Decodable {
+		try self.decode(CompoundDocument<R?, Unit>.self, from: data).data
+	}
+
 	public func decode<C>(
 		_: C.Type,
 		from data: Data

--- a/Tests/JSONAPITests/ResourceTests.swift
+++ b/Tests/JSONAPITests/ResourceTests.swift
@@ -112,6 +112,32 @@ final class ResourceTests: XCTestCase {
 		XCTAssertEqual(article, Fixtures.article)
 	}
 
+	func testDecodeNullSingle() throws {
+		// given
+		let json = try XCTUnwrap(#"{ "data": null }"#.data(using: .utf8))
+
+		// when
+		let article = try JSONAPIDecoder().decode(Article?.self, from: json)
+
+		// then
+		XCTAssertNil(article)
+	}
+
+	func testDecodeOptionalSingle() throws {
+		// given
+		let json = try XCTUnwrap(
+			Bundle.module.url(forResource: "Fixtures/Article", withExtension: "json").map {
+				try Data(contentsOf: $0)
+			}
+		)
+
+		// when
+		let article = try JSONAPIDecoder().decode(Article?.self, from: json)
+
+		// then
+		XCTAssertEqual(article, Fixtures.article)
+	}
+
 	func testDecodeArray() throws {
 		// given
 		let json = try XCTUnwrap(


### PR DESCRIPTION
### TL;DR
<!--- One-liner that summarizes the context of the change --->
Add empty-to-one `decode` method to `JSONAPIDecoder`.

### Context
<!--- Few sentences on the high level context for the change. Link to relevant design docs, discussions or related pull requests. --->
As stated in [JSONAPI specifications](https://jsonapi.org/format/#document-top-level):
> Primary data MUST be either:
> - a single [resource object](https://jsonapi.org/format/#document-resource-objects), a single [resource identifier object](https://jsonapi.org/format/#document-resource-identifier-objects), or null, for requests that target single resources
> - an array of [resource objects](https://jsonapi.org/format/#document-resource-objects), an array of [resource identifier objects](https://jsonapi.org/format/#document-resource-identifier-objects), or an empty array ([]), for requests that target resource collections

The library is currently not able to decode an empty-to-one resource (represented by `{ "data": null }`), and the `JSONAPIDecoder.decode` is throwing a decoding error in such case.
This PR aims to add a new `decode` method which will be able to decode empty-to-one resources.

### Summary of Changes
<!--- What this change does in the larger context. Specific details to highlight for review --->
- Add `decode<R>(_: R?.Type, from data: Data) throws -> R? where R: ResourceIdentifiable & Decodable`

### How to Test
N/A

### Demo
```swift
let json = #"{ "data": null }"#.data(using: .utf8)
let article = try JSONAPIDecoder().decode(Article?.self, from: json) // article == nil
```
This example was previously resulting in a decoding error.