### PR TITLE
Add conditional `Sendable` conformances

### DIFF
--- a/Sources/JSONAPI/CompoundDocument.swift
+++ b/Sources/JSONAPI/CompoundDocument.swift
@@ -112,3 +112,6 @@ extension CompoundDocument: Encodable where PrimaryData: Encodable, Meta: Encoda
 		try encoder.resourceEncoder?.encodeResources(into: &includedContainer)
 	}
 }
+
+extension CompoundDocument: Sendable where PrimaryData: Sendable, Meta: Sendable {
+}

--- a/Sources/JSONAPI/DefaultEmpty.swift
+++ b/Sources/JSONAPI/DefaultEmpty.swift
@@ -41,3 +41,6 @@ extension DefaultEmpty: Equatable where T: Equatable {
 
 extension DefaultEmpty: Hashable where T: Hashable {
 }
+
+extension DefaultEmpty: Sendable where T: Sendable {
+}

--- a/Sources/JSONAPI/InlineRelationshipMany.swift
+++ b/Sources/JSONAPI/InlineRelationshipMany.swift
@@ -93,3 +93,6 @@ extension InlineRelationshipMany {
 		case data
 	}
 }
+
+extension InlineRelationshipMany: Sendable where Destination: Sendable {
+}

--- a/Sources/JSONAPI/InlineRelationshipOne.swift
+++ b/Sources/JSONAPI/InlineRelationshipOne.swift
@@ -60,3 +60,6 @@ extension InlineRelationshipOne {
 		case data
 	}
 }
+
+extension InlineRelationshipOne: Sendable where Destination: Sendable {
+}

--- a/Sources/JSONAPI/InlineRelationshipOptional.swift
+++ b/Sources/JSONAPI/InlineRelationshipOptional.swift
@@ -64,3 +64,6 @@ extension InlineRelationshipOptional {
 		case data
 	}
 }
+
+extension InlineRelationshipOptional: Sendable where Destination: Sendable {
+}

--- a/Sources/JSONAPI/RelationshipMany.swift
+++ b/Sources/JSONAPI/RelationshipMany.swift
@@ -63,3 +63,7 @@ extension RelationshipMany: ExpressibleByArrayLiteral {
 		self.init(identifiers: elements)
 	}
 }
+
+// `Destination` is phantom — `RelationshipMany` only stores `[ResourceIdentifier]` — so the
+// conformance is unconditional.
+extension RelationshipMany: Sendable {}

--- a/Sources/JSONAPI/RelationshipOne.swift
+++ b/Sources/JSONAPI/RelationshipOne.swift
@@ -87,3 +87,7 @@ extension RelationshipOne: ExpressibleByStringLiteral where Destination.ID: Expr
 		self.init(id: Destination.ID(stringLiteral: stringLiteral))
 	}
 }
+
+// `Destination` is phantom — `RelationshipOne` only stores a `ResourceIdentifier?` — so the
+// conformance is unconditional.
+extension RelationshipOne: Sendable {}

--- a/Sources/JSONAPI/Resource.swift
+++ b/Sources/JSONAPI/Resource.swift
@@ -153,3 +153,6 @@ extension Resource: Encodable where ID: Encodable, Attributes: Encodable, Relati
 		}
 	}
 }
+
+extension Resource: Sendable where ID: Sendable, Attributes: Sendable, Relationships: Sendable {
+}

--- a/Sources/JSONAPI/ResourceBody.swift
+++ b/Sources/JSONAPI/ResourceBody.swift
@@ -114,3 +114,6 @@ extension ResourceBody where Relationships == Unit {
 
 extension ResourceBody: Equatable where ID: Equatable, Attributes: Equatable, Relationships: Equatable {
 }
+
+extension ResourceBody: Sendable where ID: Sendable, Attributes: Sendable, Relationships: Sendable {
+}

--- a/Sources/JSONAPI/ResourceIdentifier.swift
+++ b/Sources/JSONAPI/ResourceIdentifier.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A unique identifier for a JSON:API resource.
-public struct ResourceIdentifier: Hashable, Codable {
+public struct ResourceIdentifier: Hashable, Codable, Sendable {
 	public var type: String
 	public var id: String
 

--- a/Sources/JSONAPI/Unit.swift
+++ b/Sources/JSONAPI/Unit.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 
-/// A terminal type that conforms to `Equatable` and `Codable`.
-public struct Unit: Equatable, Codable {
+/// A terminal type that conforms to `Equatable`, `Codable` and `Sendable`.
+public struct Unit: Equatable, Codable, Sendable {
+	public init() {}
 }

--- a/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
+++ b/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
@@ -527,13 +527,21 @@ extension InheritedTypeListSyntax {
 	fileprivate static func makeDefinitionAssociatedTypesInheritedTypeList(
 		attachedTo declaration: some DeclGroupSyntax
 	) -> InheritedTypeListSyntax {
-		let inheritedTypes = [
-			declaration.conformsToEquatable
-				? InheritedTypeSyntax(type: TypeSyntax("Equatable"), trailingComma: .commaToken())
-				: nil,
-			InheritedTypeSyntax(type: TypeSyntax("Codable")),
-		].compactMap { $0 }
-		return InheritedTypeListSyntax(inheritedTypes)
+		var types: [InheritedTypeSyntax] = []
+		if declaration.conformsToEquatable {
+			types.append(InheritedTypeSyntax(type: TypeSyntax("Equatable")))
+		}
+		types.append(InheritedTypeSyntax(type: TypeSyntax("Codable")))
+		if declaration.conformsToSendable {
+			types.append(InheritedTypeSyntax(type: TypeSyntax("Sendable")))
+		}
+
+		// Re-apply trailing commas so every entry except the last has one.
+		let withCommas = types.enumerated().map { index, type -> InheritedTypeSyntax in
+			guard index < types.count - 1 else { return type }
+			return type.with(\.trailingComma, .commaToken())
+		}
+		return InheritedTypeListSyntax(withCommas)
 	}
 }
 
@@ -545,6 +553,16 @@ extension DeclGroupSyntax {
 
 		return inheritanceClause.inheritedTypes.contains {
 			$0.type.as(IdentifierTypeSyntax.self)?.name.text == "Equatable"
+		}
+	}
+
+	fileprivate var conformsToSendable: Bool {
+		guard let inheritanceClause else {
+			return false
+		}
+
+		return inheritanceClause.inheritedTypes.contains {
+			$0.type.as(IdentifierTypeSyntax.self)?.name.text == "Sendable"
 		}
 	}
 }

--- a/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
+++ b/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
@@ -361,6 +361,87 @@ final class ResourceWrapperMacroTests: XCTestCase {
 		}
 	}
 
+	func testResourceWrapperPropagatesSendable() {
+		assertMacro {
+			"""
+			@ResourceWrapper(type: "people")
+			struct Person: Sendable {
+				var id: String
+
+				@ResourceAttribute var firstName: String
+				@ResourceRelationship var related: Person?
+			}
+			"""
+		} expansion: {
+			"""
+			struct Person: Sendable {
+				var id: String
+
+				var firstName: String
+				var related: Person?
+			}
+
+			extension Person: JSONAPI.ResourceDefinitionProviding {
+				struct Definition: JSONAPI.ResourceDefinition {
+					struct Attributes: Codable, Sendable {
+						var firstName: String
+					}
+					struct Relationships: Codable, Sendable {
+						var related: JSONAPI.InlineRelationshipOptional<Person>?
+					}
+					static let resourceType = "people"
+				}
+				struct BodyDefinition: JSONAPI.ResourceDefinition {
+					struct Attributes: Codable, Sendable {
+						var firstName: String?
+					}
+					struct Relationships: Codable, Sendable {
+						var related: JSONAPI.RelationshipOne<Person>?
+					}
+					static let resourceType = Definition.resourceType
+				}
+				typealias Wrapped = JSONAPI.Resource<String, Definition>
+				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
+			}
+
+			extension Person: JSONAPI.ResourceIdentifiable {
+			}
+
+			extension Person: JSONAPI.ResourceLinkageProviding {
+				typealias ID = String
+			}
+
+			extension Person: Codable {
+				init(from decoder: any Decoder) throws {
+					let wrapped = try Wrapped(from: decoder)
+					self.id = wrapped.id
+					self.firstName = wrapped.firstName
+					self.related = wrapped.related?.resource
+				}
+				func encode(to encoder: any Encoder) throws {
+					let attributes = Wrapped.Attributes(firstName: self.firstName)
+					let relationships = Wrapped.Relationships(related: .init(self.related))
+					let wrapped = Wrapped(id: self.id, attributes: attributes, relationships: relationships)
+					try wrapped.encode(to: encoder)
+				}
+			}
+
+			extension Person {
+				static func createBody(id: String? = nil, firstName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
+					let attributes = Body.Attributes(firstName: firstName)
+					let relationships = Body.Relationships(related: related)
+					return Body(id: id, attributes: attributes, relationships: relationships)
+				}
+				static func updateBody(id: String, firstName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
+					let attributes = Body.Attributes(firstName: firstName)
+					let relationships = Body.Relationships(related: related)
+					return Body(id: id, attributes: attributes, relationships: relationships)
+				}
+			}
+			"""
+		}
+	}
+
 	func testAvailability() {
 		assertMacro {
 			"""

--- a/Tests/JSONAPITests/SendableTests.swift
+++ b/Tests/JSONAPITests/SendableTests.swift
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under
+// the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+import JSONAPI
+import XCTest
+
+final class SendableTests: XCTestCase {
+	private struct SendableAttributes: Codable, Sendable {
+		var name: String
+	}
+
+	private struct SendableRelationships: Codable, Sendable {
+		var owner: RelationshipOne<SendableResource>
+	}
+
+	private struct SendableDefinition: ResourceDefinition {
+		typealias Attributes = SendableAttributes
+		typealias Relationships = SendableRelationships
+		static let resourceType = "samples"
+	}
+
+	private typealias SendableResource = Resource<String, SendableDefinition>
+	private typealias SendableResourceBody = ResourceBody<String, SendableDefinition>
+
+	// MARK: - Unconditional conformances
+
+	func testUnitIsSendable() {
+		acceptSendable(JSONAPI.Unit())
+	}
+
+	func testResourceIdentifierIsSendable() {
+		acceptSendable(ResourceIdentifier(type: "samples", id: "1"))
+	}
+
+	func testRelationshipOneIsSendable() {
+		acceptSendable(RelationshipOne<SendableResource>(id: "1"))
+	}
+
+	func testRelationshipManyIsSendable() {
+		acceptSendable(RelationshipMany<SendableResource>(identifiers: ["1", "2"]))
+	}
+
+	// MARK: - Conditional conformances
+
+	func testResourceIsSendable_whenGenericsAreSendable() {
+		let resource = SendableResource(
+			id: "1",
+			attributes: .init(name: "n"),
+			relationships: .init(owner: RelationshipOne(id: "2"))
+		)
+		acceptSendable(resource)
+	}
+
+	func testResourceBodyIsSendable_whenGenericsAreSendable() {
+		let body = SendableResourceBody(
+			id: "1",
+			attributes: .init(name: "n"),
+			relationships: .init(owner: RelationshipOne(id: "2"))
+		)
+		acceptSendable(body)
+	}
+
+	func testInlineRelationshipOneIsSendable_whenDestinationIsSendable() {
+		let inline = InlineRelationshipOne(
+			SendableResource(
+				id: "1",
+				attributes: .init(name: "n"),
+				relationships: .init(owner: RelationshipOne(id: "2"))
+			)
+		)
+		acceptSendable(inline)
+	}
+
+	func testInlineRelationshipManyIsSendable_whenDestinationIsSendable() {
+		let inline = InlineRelationshipMany<SendableResource>([])
+		acceptSendable(inline)
+	}
+
+	func testInlineRelationshipOptionalIsSendable_whenDestinationIsSendable() {
+		let inline = InlineRelationshipOptional<SendableResource>(nil)
+		acceptSendable(inline)
+	}
+
+	func testCompoundDocumentIsSendable_whenGenericsAreSendable() {
+		let document = CompoundDocument<SendableResource, JSONAPI.Unit>(
+			data: SendableResource(
+				id: "1",
+				attributes: .init(name: "n"),
+				relationships: .init(owner: RelationshipOne(id: "2"))
+			)
+		)
+		acceptSendable(document)
+	}
+
+	func testDefaultEmptyIsSendable_whenWrappedIsSendable() {
+		acceptSendable(DefaultEmpty<[Int]>(wrappedValue: []))
+	}
+
+	private func acceptSendable<T: Sendable>(_ value: T) {
+		_ = value
+	}
+}


### PR DESCRIPTION
### TL;DR
<!--- One-liner that summarizes the context of the change --->
Add conditional `Sendable` conformances.

### Context
<!--- Few sentences on the high level context for the change. Link to relevant design docs, discussions or related pull requests. --->
With Swift 6's strict concurrency checking (and Xcode 26.5's default warnings), a value produced on the main actor and handed to a non-isolated `@Sendable` closure must conform to `Sendable`. None of the library's resource types declared `Sendable`, which forced every downstream app to add per-target retroactive conformances such as:
 ```swift
  extension JSONAPI.ResourceBody: @retroactive @unchecked Sendable {}
```

Conditional Sendable belongs in the library, mirroring how it already conditionally provides Equatable and Codable.

### Summary of Changes
<!--- What this change does in the larger context. Specific details to highlight for review --->
  - Add unconditional Sendable conformance to Unit, ResourceIdentifier, RelationshipOne, RelationshipMany — their stored properties are always Sendable.
  - Add conditional Sendable conformance to Resource, ResourceBody, InlineRelationshipOne, InlineRelationshipMany, InlineRelationshipOptional, CompoundDocument, DefaultEmpty — gated on
  the generic parameters that show up in stored properties.
  - @ResourceWrapper macro now propagates Sendable to the generated Attributes and Relationships structs when the wrapper itself conforms to Sendable (same detection pattern already used
  for Equatable).
  - Add a public init() to Unit so it's constructible from outside the module (used by the new tests).
  - Add SendableTests (11 type-witness checks) and a testResourceWrapperPropagatesSendable macro snapshot test to lock the behavior in.

### How to Test
<!--- Describe how to test the change end-to-end if needed --->
N/A — covered by the new tests.

### Demo
<!--- Add videos and / or screenshots demonstrating the change when applicable --->
```swift
  @ResourceWrapper(type: "people")
  struct Person: Sendable {
      var id: String

      @ResourceAttribute var firstName: String
      @ResourceRelationship var related: Person?
  }

  // `Person.Body` is now `Sendable`, so values can flow into a non-isolated
  // `@Sendable` closure without "sending main actor-isolated 'body' risks
  // causing data races" warnings.
  let body = Person.createBody(id: "1", firstName: "Dan")
  Task.detached {
      await send(body)
  }
```