### PR TITLE
Support optional to-many relationships in @ResourceRelationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,14 @@ let data = try encoder.encode(articles)
 > **_NOTE:_** To provide greater flexibility, the library allows a field annotated with `@ResourceRelationship` and marked
 > as `Optional` to be omitted from the JSON:API response. While this behavior deviates from the JSON:API specification
 > —which recommends including relationship fields even when they are empty—it can be useful in cases where strict adherence
-> to the spec is either impractical or unnecessary.
+> to the spec is either impractical or unnecessary. This applies to "to-many" relationships as well:
+>
+> ```swift
+> @ResourceRelationship var comments: [Comment]?
+> ```
+>
+> Decoding treats a missing `comments` field the same as `nil`; encoding treats `nil` the same as an empty array, since
+> there is no way to distinguish an empty "to-many" relationship from a missing one once encoded.
 
 ## Creating and updating resources
 

--- a/Sources/JSONAPI/InlineRelationshipMany.swift
+++ b/Sources/JSONAPI/InlineRelationshipMany.swift
@@ -17,6 +17,15 @@ public struct InlineRelationshipMany<Destination> {
 	public init(_ resources: [Destination]) {
 		self.resources = resources
 	}
+
+	/// Creates a to-many relationship from an optional array, treating `nil` the same as an empty array.
+	///
+	/// This overload exists so that a property annotated with `@ResourceRelationship` and marked as `Optional`
+	/// compiles when its wrapped type is an array (e.g. `var comments: [Comment]?`), mirroring the initializer
+	/// ``InlineRelationshipOptional`` already provides for optional to-one relationships.
+	public init(_ resources: [Destination]?) {
+		self.init(resources ?? [])
+	}
 }
 
 extension InlineRelationshipMany: RandomAccessCollection {

--- a/Tests/JSONAPITests/ResourceWrapperTests.swift
+++ b/Tests/JSONAPITests/ResourceWrapperTests.swift
@@ -54,6 +54,14 @@ final class ResourceWrapperTests: XCTestCase {
 		@ResourceRelationship var favorite: ResourceWrapperTests.Person?
 	}
 
+	@ResourceWrapper(type: "teams")
+	fileprivate struct Team: Equatable {
+		var id: String
+
+		@ResourceAttribute var name: String
+		@ResourceRelationship var members: [ResourceWrapperTests.Person]?
+	}
+
 	private enum Fixtures {
 		static let article = Article(
 			id: "1",
@@ -162,12 +170,60 @@ final class ResourceWrapperTests: XCTestCase {
 		}
 	}
 
+	func testDecodeMissingArrayRelationship() throws {
+		// given
+		let json = try XCTUnwrap(
+			#"{ "data": { "type": "teams", "id": "1", "attributes": { "name": "Engineering" } } }"#
+				.data(using: .utf8)
+		)
+
+		// when
+		let team = try JSONAPIDecoder().decode(Team.self, from: json)
+
+		// then
+		XCTAssertEqual(team, Team(id: "1", name: "Engineering", members: nil))
+	}
+
+	func testDecodeEmptyArrayRelationship() throws {
+		// given
+		let json = try XCTUnwrap(
+			#"""
+			{
+			  "data": {
+			    "type": "teams",
+			    "id": "1",
+			    "attributes": { "name": "Engineering" },
+			    "relationships": { "members": { "data": [] } }
+			  }
+			}
+			"""#.data(using: .utf8)
+		)
+
+		// when
+		let team = try JSONAPIDecoder().decode(Team.self, from: json)
+
+		// then
+		XCTAssertEqual(team, Team(id: "1", name: "Engineering", members: []))
+	}
+
 	func testEncodeSingle() {
 		assertSnapshot(of: Fixtures.article, as: .jsonAPI())
 	}
 
 	func testEncodeArray() {
 		assertSnapshot(of: Fixtures.articles, as: .jsonAPI())
+	}
+
+	func testEncodeOptionalArrayRelationship() {
+		let teamWithMembers = Team(
+			id: "1",
+			name: "Engineering",
+			members: [Person(id: "9", firstName: "Dan", lastName: "Gebhardt", twitter: "dgeb")]
+		)
+		let teamWithoutMembers = Team(id: "2", name: "Support", members: nil)
+
+		assertSnapshot(of: teamWithMembers, as: .jsonAPI())
+		assertSnapshot(of: teamWithoutMembers, as: .jsonAPI())
 	}
 
 	func testEncodeBodyOnlyAttributes() {

--- a/Tests/JSONAPITests/__Snapshots__/ResourceWrapperTests/testEncodeOptionalArrayRelationship.1.json
+++ b/Tests/JSONAPITests/__Snapshots__/ResourceWrapperTests/testEncodeOptionalArrayRelationship.1.json
@@ -1,0 +1,30 @@
+{
+  "data" : {
+    "attributes" : {
+      "name" : "Engineering"
+    },
+    "id" : "1",
+    "relationships" : {
+      "members" : {
+        "data" : [
+          {
+            "id" : "9",
+            "type" : "people"
+          }
+        ]
+      }
+    },
+    "type" : "teams"
+  },
+  "included" : [
+    {
+      "attributes" : {
+        "firstName" : "Dan",
+        "lastName" : "Gebhardt",
+        "twitter" : "dgeb"
+      },
+      "id" : "9",
+      "type" : "people"
+    }
+  ]
+}

--- a/Tests/JSONAPITests/__Snapshots__/ResourceWrapperTests/testEncodeOptionalArrayRelationship.2.json
+++ b/Tests/JSONAPITests/__Snapshots__/ResourceWrapperTests/testEncodeOptionalArrayRelationship.2.json
@@ -1,0 +1,19 @@
+{
+  "data" : {
+    "attributes" : {
+      "name" : "Support"
+    },
+    "id" : "2",
+    "relationships" : {
+      "members" : {
+        "data" : [
+
+        ]
+      }
+    },
+    "type" : "teams"
+  },
+  "included" : [
+
+  ]
+}


### PR DESCRIPTION
## Support optional to-many relationships in `@ResourceRelationship`

A property annotated with `@ResourceRelationship` and marked `Optional` compiles fine when its
wrapped type is a single resource, but fails to compile when the wrapped type is an array of
resources, e.g.:

```swift
@ResourceWrapper(type: "teams")
struct Team: Equatable {
    var id: String

    @ResourceAttribute var name: String
    @ResourceRelationship var members: [Person]?  // ❌ fails to compile
}
```

```
error: value of optional type '[Person]?' must be unwrapped to a value of type '[Person]'
```

**Root cause**

`@ResourceRelationship` maps an optional single resource (`Person?`) to `InlineRelationshipOptional<Person>`,
whose initializer already accepts an optional (`init(_ resource: Destination?)`) - so the macro's generated
`.init(self.author)` call compiles regardless of whether `self.author` is `nil`.

An optional array of resources (`[Person]?`) maps to `InlineRelationshipMany<Person>`, but that type only had
`init(_ resources: [Destination])` - no initializer accepting an optional array. The same macro-generated
`.init(self.members)` call then fails to compile, since there's nothing for the optional array to satisfy.

**Changes**
- Add `InlineRelationshipMany.init(_ resources: [Destination]?)`, mirroring `InlineRelationshipOptional`'s
  existing optional-accepting initializer. Treats `nil` the same as an empty array, since `resources` is
  stored non-optionally.
- Add a real (non-snapshot) regression test in `ResourceWrapperTests` using `@ResourceRelationship` on an
  optional array property directly - the existing macro-expansion snapshot test in `JSONAPIMacrosTests`
  already expected this to expand to `.init(self.members)`, but that target doesn't depend on `JSONAPI` and
  so can't actually compile the expansion, which is how this went unnoticed.
- Cover decoding too (missing relationship key → `nil`, present-but-empty → `[]`), exercising the existing
  "flexible optional relationships" decoding path (#16) for the array case specifically, which previously
  only had test coverage for to-one relationships.
- Update the README note on optional relationships to clarify it also applies to "to-many" relationships.

**Tradeoffs**
- `nil` and `[]` are indistinguishable once encoded (`InlineRelationshipMany` always writes a `data` array,
  never omits the relationship or writes `null`) - same limitation the to-many relationship type already
  had before this change, just now reachable from an optional property too.