### PR TITLE
Mark @ResourceWrapper-generated extensions and Definition types nonisolated

### DIFF
--- a/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
+++ b/Sources/JSONAPIMacros/ResourceWrapper/ResourceWrapperMacro.swift
@@ -108,7 +108,7 @@ extension ExtensionDeclSyntax {
 		return try ExtensionDeclSyntax(
 			"""
 			\(declaration.attributes.availability)
-			extension \(type): JSONAPI.ResourceDefinitionProviding\(MemberBlockSyntax(members: members))
+			nonisolated extension \(type): JSONAPI.ResourceDefinitionProviding\(MemberBlockSyntax(members: members))
 			"""
 		)
 	}
@@ -118,7 +118,7 @@ extension ExtensionDeclSyntax {
 		providingExtensionsOf type: some TypeSyntaxProtocol
 	) throws -> ExtensionDeclSyntax {
 		try ExtensionDeclSyntax(
-			"\(declaration.attributes.availability)\nextension \(type): JSONAPI.ResourceIdentifiable {}"
+			"\(declaration.attributes.availability)\nnonisolated extension \(type): JSONAPI.ResourceIdentifiable {}"
 		)
 	}
 
@@ -147,7 +147,7 @@ extension ExtensionDeclSyntax {
 		return try ExtensionDeclSyntax(
 			"""
 			\(declaration.attributes.availability)
-			extension \(type): JSONAPI.ResourceLinkageProviding\(MemberBlockSyntax(members: members))
+			nonisolated extension \(type): JSONAPI.ResourceLinkageProviding\(MemberBlockSyntax(members: members))
 			"""
 		)
 	}
@@ -212,7 +212,7 @@ extension ExtensionDeclSyntax {
 		return try ExtensionDeclSyntax(
 			"""
 			\(declaration.attributes.availability)
-			extension \(type): Codable\(MemberBlockSyntax(members: members))
+			nonisolated extension \(type): Codable\(MemberBlockSyntax(members: members))
 			"""
 		)
 	}
@@ -285,7 +285,7 @@ extension ExtensionDeclSyntax {
 		}
 
 		return try ExtensionDeclSyntax(
-			"\(declaration.attributes.availability)\nextension \(type)\(MemberBlockSyntax(members: members))"
+			"\(declaration.attributes.availability)\nnonisolated extension \(type)\(MemberBlockSyntax(members: members))"
 		)
 	}
 }
@@ -300,7 +300,7 @@ extension StructDeclSyntax {
 		attributesEmptyRepresentable: Bool,
 		relationshipsEmptyRepresentable: Bool
 	) throws -> StructDeclSyntax {
-		try StructDeclSyntax("\(modifiers)struct Definition: JSONAPI.ResourceDefinition") {
+		try StructDeclSyntax("\(modifiers)nonisolated struct Definition: JSONAPI.ResourceDefinition") {
 			if !resourceAttributes.isEmpty {
 				try StructDeclSyntax.makeDefinitionAttributes(
 					arrayAttributes: AttributeListSyntax {
@@ -331,7 +331,7 @@ extension StructDeclSyntax {
 		resourceAttributes: [VariableDeclSyntax],
 		resourceRelationships: [VariableDeclSyntax]
 	) throws -> StructDeclSyntax {
-		try StructDeclSyntax("\(modifiers)struct BodyDefinition: JSONAPI.ResourceDefinition") {
+		try StructDeclSyntax("\(modifiers)nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition") {
 			if !resourceAttributes.isEmpty {
 				try StructDeclSyntax.makeDefinitionAttributes(
 					modifiers: modifiers,

--- a/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
+++ b/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
@@ -105,8 +105,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var links: [Link]?
 			}
 
-			extension Article: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Article: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Codable {
 						var title: String
 					}
@@ -118,7 +118,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					static let resourceType = "articles"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Codable {
 						var title: String?
 					}
@@ -134,14 +134,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<UUID, BodyDefinition>
 			}
 
-			extension Article: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Article: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Article: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Article: JSONAPI.ResourceLinkageProviding {
 				typealias ID = UUID
 			}
 
-			extension Article: Codable {
+			nonisolated extension Article: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -159,7 +159,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Article {
+			nonisolated extension Article {
 				static func createBody(id: UUID? = nil, title: String? = nil, author: JSONAPI.RelationshipOne<Person>? = nil, comments: JSONAPI.RelationshipMany<Comment>? = nil, edition: JSONAPI.RelationshipOne<Edition>? = nil, links: JSONAPI.RelationshipMany<Link>? = nil) -> Article.Body {
 					let attributes = Body.Attributes(title: title)
 					let relationships = Body.Relationships(author: author, comments: comments, edition: edition, links: links)
@@ -197,8 +197,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var related: Person?
 			}
 
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						private enum CodingKeys: String, CodingKey {
 						    case firstName = "first_name"
@@ -218,7 +218,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					static let resourceType = "people"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						private enum CodingKeys: String, CodingKey {
 						    case firstName = "first_name"
@@ -239,14 +239,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				typealias ID = String
 			}
 
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -262,7 +262,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Person {
+			nonisolated extension Person {
 				static func createBody(id: String? = nil, firstName: String? = nil, lastName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
 					let attributes = Body.Attributes(firstName: firstName, lastName: lastName)
 					let relationships = Body.Relationships(related: related)
@@ -300,8 +300,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				public var related: Person?
 			}
 
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				public struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				public nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					public struct Attributes: Equatable, Codable {
 						public var firstName: String
 						var lastName: String
@@ -314,7 +314,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					public static let resourceType = "people"
 				}
-				public struct BodyDefinition: JSONAPI.ResourceDefinition {
+				public nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					public struct Attributes: Equatable, Codable {
 						public var firstName: String?
 						var lastName: String?
@@ -328,14 +328,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				public typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				public typealias ID = String
 			}
 
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				public init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -351,7 +351,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Person {
+			nonisolated extension Person {
 				public static func createBody(id: String? = nil, firstName: String? = nil, lastName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
 					let attributes = Body.Attributes(firstName: firstName, lastName: lastName)
 					let relationships = Body.Relationships(related: related)
@@ -387,8 +387,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var related: Person?
 			}
 
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Codable, Sendable {
 						var firstName: String
 					}
@@ -400,7 +400,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					static let resourceType = "people"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Codable, Sendable {
 						var firstName: String?
 					}
@@ -413,14 +413,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				typealias ID = String
 			}
 
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -435,7 +435,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Person {
+			nonisolated extension Person {
 				static func createBody(id: String? = nil, firstName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
 					let attributes = Body.Attributes(firstName: firstName)
 					let relationships = Body.Relationships(related: related)
@@ -468,11 +468,11 @@ final class ResourceWrapperMacroTests: XCTestCase {
 			}
 
 			@available(iOS, unavailable)
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				public struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				public nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					public static let resourceType = "people"
 				}
-				public struct BodyDefinition: JSONAPI.ResourceDefinition {
+				public nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					public static let resourceType = Definition.resourceType
 				}
 				public typealias Wrapped = JSONAPI.Resource<String, Definition>
@@ -480,16 +480,16 @@ final class ResourceWrapperMacroTests: XCTestCase {
 			}
 
 			@available(iOS, unavailable)
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
 			@available(iOS, unavailable)
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				public typealias ID = String
 			}
 
 			@available(iOS, unavailable)
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				public init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -501,7 +501,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 			}
 
 			@available(iOS, unavailable)
-			extension Person {
+			nonisolated extension Person {
 				public static func createBody(id: String? = nil) -> Person.Body {
 					return Body(id: id)
 				}
@@ -533,15 +533,15 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var tags: [String]
 			}
 
-			extension Schedule: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Schedule: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var name: String
 						@DefaultEmpty var tags: [String]
 					}
 					static let resourceType = "schedules"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var name: String?
 						var tags: [String]?
@@ -552,14 +552,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<UUID, BodyDefinition>
 			}
 
-			extension Schedule: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Schedule: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Schedule: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Schedule: JSONAPI.ResourceLinkageProviding {
 				typealias ID = UUID
 			}
 
-			extension Schedule: Codable {
+			nonisolated extension Schedule: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -573,7 +573,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Schedule {
+			nonisolated extension Schedule {
 				static func createBody(id: UUID? = nil, name: String? = nil, tags: [String]? = nil) -> Schedule.Body {
 					let attributes = Body.Attributes(name: name, tags: tags)
 					return Body(id: id, attributes: attributes)
@@ -609,8 +609,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var related: Person?
 			}
 
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable, JSONAPI.EmptyRepresentable {
 						var firstName: String?
 						var lastName: String?
@@ -626,7 +626,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					static let resourceType = "people"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var firstName: String?
 						var lastName: String?
@@ -640,14 +640,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				typealias ID = String
 			}
 
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -663,7 +663,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Person {
+			nonisolated extension Person {
 				static func createBody(id: String? = nil, firstName: String? = nil, lastName: String? = nil, related: JSONAPI.RelationshipOne<Person>? = nil) -> Person.Body {
 					let attributes = Body.Attributes(firstName: firstName, lastName: lastName)
 					let relationships = Body.Relationships(related: related)
@@ -699,15 +699,15 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var lastName: String?
 			}
 
-			extension Person: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Person: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var firstName: String
 						var lastName: String?
 					}
 					static let resourceType = "people"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var firstName: String?
 						var lastName: String?
@@ -718,14 +718,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Person: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Person: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Person: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Person: JSONAPI.ResourceLinkageProviding {
 				typealias ID = String
 			}
 
-			extension Person: Codable {
+			nonisolated extension Person: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -739,7 +739,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Person {
+			nonisolated extension Person {
 				static func createBody(id: String? = nil, firstName: String? = nil, lastName: String? = nil) -> Person.Body {
 					let attributes = Body.Attributes(firstName: firstName, lastName: lastName)
 					return Body(id: id, attributes: attributes)
@@ -773,8 +773,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				var author: Person
 			}
 
-			extension Comment: JSONAPI.ResourceDefinitionProviding {
-				struct Definition: JSONAPI.ResourceDefinition {
+			nonisolated extension Comment: JSONAPI.ResourceDefinitionProviding {
+				nonisolated struct Definition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable, JSONAPI.EmptyRepresentable {
 						var body: String?
 						static var empty: Self {
@@ -786,7 +786,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 					}
 					static let resourceType = "comments"
 				}
-				struct BodyDefinition: JSONAPI.ResourceDefinition {
+				nonisolated struct BodyDefinition: JSONAPI.ResourceDefinition {
 					struct Attributes: Equatable, Codable {
 						var body: String?
 					}
@@ -799,14 +799,14 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				typealias Body = JSONAPI.ResourceBody<String, BodyDefinition>
 			}
 
-			extension Comment: JSONAPI.ResourceIdentifiable {
+			nonisolated extension Comment: JSONAPI.ResourceIdentifiable {
 			}
 
-			extension Comment: JSONAPI.ResourceLinkageProviding {
+			nonisolated extension Comment: JSONAPI.ResourceLinkageProviding {
 				typealias ID = String
 			}
 
-			extension Comment: Codable {
+			nonisolated extension Comment: Codable {
 				init(from decoder: any Decoder) throws {
 					let wrapped = try Wrapped(from: decoder)
 					self.id = wrapped.id
@@ -821,7 +821,7 @@ final class ResourceWrapperMacroTests: XCTestCase {
 				}
 			}
 
-			extension Comment {
+			nonisolated extension Comment {
 				static func createBody(id: String? = nil, body: String? = nil, author: JSONAPI.RelationshipOne<Person>? = nil) -> Comment.Body {
 					let attributes = Body.Attributes(body: body)
 					let relationships = Body.Relationships(author: author)


### PR DESCRIPTION
Fixes #19

### TL;DR
Mark `@ResourceWrapper`'s generated extensions and `Definition`/`BodyDefinition` types `nonisolated` so the macro output no longer depends on the consuming module's default actor-isolation setting.

### Context
Xcode 26's "Approachable Concurrency" makes `@MainActor` the default isolation for any declaration that doesn't opt out explicitly. `@ResourceWrapper` generates several `extension Person: ...` conformances and a nested `Definition` struct without marking them `nonisolated`, so under that default they inherit `@MainActor` isolation. Since `ResourceDefinition`/`ResourceDefinitionProviding` are ordinary nonisolated protocols, this produces:

```
error: conformance of 'Person' to protocol 'ResourceDefinitionProviding' crosses into main actor-isolated code and can cause data races
```

Reported in #19, where the reporter found that adding `nonisolated` to their own model works around it. Resource models are plain data-transfer types encoded/decoded across concurrency domains, so they shouldn't be actor-isolated regardless of what isolation default the consuming module picked — the fix belongs in the macro.

### Summary of Changes
- `@ResourceWrapper` now emits `nonisolated` on all 5 generated extensions (`ResourceDefinitionProviding`, `ResourceIdentifiable`, `ResourceLinkageProviding`, `Codable`, and the body-factory extension).
- The generated `Definition` and `BodyDefinition` struct declarations are also marked `nonisolated`, since nested type declarations are independent isolation-inference roots and don't inherit isolation from their enclosing (now-nonisolated) extension.
- `Attributes`/`Relationships` are intentionally left unmarked: they hold mutable `var` stored properties, and `nonisolated` on a mutable stored property is a hard error in the Swift 6 language mode. They don't need it anyway — the compiler error was specifically about `Definition`'s conformance, not these nested value types.
- Updated the `ResourceWrapperMacroTests` expansion snapshots to match.

### How to Test
Verified against the reporter's exact repro (`Person` with `id`/`firstName`/`lastName`/`twitter`) using `swift build -Xswiftc -swift-version -Xswiftc 6 -Xswiftc -default-isolation -Xswiftc MainActor` on a client target depending on this branch:
- Before this change: fails with the reported "crosses into main actor-isolated code" error.
- After this change: builds cleanly.

Also ran the full existing test suite (`swift test`), all green with no new warnings.

### Demo
```swift
@ResourceWrapper(type: "people")
struct Person: Equatable {
    var id: String

    @ResourceAttribute var firstName: String
    @ResourceAttribute var lastName: String
    @ResourceAttribute var twitter: String?
}
// Compiles under `-default-isolation MainActor` (Xcode 26's Approachable
// Concurrency default) without needing to mark `Person` itself `nonisolated`.
```