### PR TITLE
Update dependencies while preserving Swift 5.9 compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,18 +1,27 @@
 {
   "pins" : [
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
+        "version" : "1.7.0"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
-        "version" : "0.5.2"
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "6d932a79e7173b275b96c600c86c603cf84f153c",
-        "version" : "1.17.4"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {
@@ -41,8 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,22 @@
 import CompilerPluginSupport
 import PackageDescription
 
+#if compiler(>=6.3)
+let packageDependencies: [Package.Dependency] = [
+	.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"604.0.0"),
+	.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.5"),
+	.package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.4"),
+	.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
+]
+#else
+let packageDependencies: [Package.Dependency] = [
+	.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"510.0.0"),
+	.package(url: "https://github.com/pointfreeco/swift-macro-testing", "0.5.2"..<"0.6.0"),
+	.package(url: "https://github.com/pointfreeco/swift-snapshot-testing", "1.17.4"..<"1.18.0"),
+	.package(url: "https://github.com/apple/swift-docc-plugin", "1.3.0"..<"1.4.0"),
+]
+#endif
+
 let package = Package(
 	name: "swift-jsonapi",
 	platforms: [
@@ -18,12 +34,7 @@ let package = Package(
 			targets: ["JSONAPI"]
 		)
 	],
-	dependencies: [
-		.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"511.0.0"),
-		.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
-		.package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
-		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-	],
+	dependencies: packageDependencies,
 	targets: [
 		.target(
 			name: "JSONAPI",

--- a/Sources/JSONAPIMacros/Helpers/Extensions.swift
+++ b/Sources/JSONAPIMacros/Helpers/Extensions.swift
@@ -88,7 +88,7 @@ extension TypeSyntax {
 			let genericArgumentClause = identifierType.genericArgumentClause,
 			let firstArgument = genericArgumentClause.arguments.first
 		{
-			return firstArgument.argument
+			return firstArgument.argument.as(TypeSyntax.self)
 		}
 
 		return nil
@@ -122,7 +122,7 @@ extension TypeSyntax {
 			let genericArgumentClause = identifierType.genericArgumentClause,
 			let firstArgument = genericArgumentClause.arguments.first
 		{
-			return firstArgument.argument
+			return firstArgument.argument.as(TypeSyntax.self)
 		}
 
 		return nil

--- a/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
+++ b/Tests/JSONAPIMacrosTests/ResourceWrapperMacroTests.swift
@@ -88,8 +88,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 
 				@ResourceAttribute var title: String
 				@ResourceRelationship var author: Person
-				@ResourceRelationship var comments: [Comment]
-				@ResourceRelationship var edition: Edition?
+				@ResourceRelationship var comments: Array<Comment>
+				@ResourceRelationship var edition: Optional<Edition>
 				@ResourceRelationship var links: [Link]?
 			}
 			"""
@@ -100,8 +100,8 @@ final class ResourceWrapperMacroTests: XCTestCase {
 
 				var title: String
 				var author: Person
-				var comments: [Comment]
-				var edition: Edition?
+				var comments: Array<Comment>
+				var edition: Optional<Edition>
 				var links: [Link]?
 			}
 


### PR DESCRIPTION
### TL;DR

Update dependencies while preserving compatibility with Swift 5.9 and Swift 5.10.

### Context

Swift 6.3.2 resolves and builds the updated dependency graph, but older compilers cannot compile every dependency in that graph. The package manifest now selects dependency ranges based on the active compiler: Swift 6.3 and later use the updated graph, while earlier compilers use compatible release lines.

Keeping this selection in the default manifest avoids exact-match behavior from version-specific manifests. Future compilers such as Swift 6.4 continue to select the updated graph without requiring another manifest.

The compatibility ranges exclude versions that require a newer Swift toolchain, allow patch updates, and avoid exact pins that can conflict when `swift-jsonapi` is resolved alongside other packages.

### Summary of Changes

- Update the Swift 6.3 and later dependency graph:
  - SwiftSyntax to 603.0.2
  - MacroTesting to 0.6.5
  - SnapshotTesting to 1.19.4
  - DocC plugin to 1.5.0
- Keep earlier compilers on compatible dependency ranges:
  - SwiftSyntax 509.x
  - MacroTesting 0.5.x
  - SnapshotTesting 1.17.x
  - DocC plugin 1.3.x
- Add explicit `TypeSyntax` conversions required across the supported SwiftSyntax versions.
- Cover long-form `Array<Element>` and `Optional<Wrapped>` syntax in the resource wrapper macro test. The existing test still covers shorthand syntax through `[Link]?`.

### How to Test

- Xcode 15.4 with Swift 5.10: all 72 tests pass.
- Swift 6.3.2: all 72 tests pass.
